### PR TITLE
[Refactor] 모달 공용 컴포넌트 스크롤 방지, esc 닫기 구현 및 모달 커스텀화 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-kakao-maps-sdk": "^1.1.26",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
+        "tailwind-merge": "^2.3.0",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4",
         "webpack": "^5.91.0"
@@ -17426,6 +17427,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.3.0.tgz",
+      "integrity": "sha512-vkYrLpIP+lgR0tQCG6AP7zZXCTLc1Lnv/CCRT3BqJ9CZ3ui2++GPaGb1x/ILsINIMSYqqvrpqjUFsMNLlW99EA==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-kakao-maps-sdk": "^1.1.26",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
+    "tailwind-merge": "^2.3.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4",
     "webpack": "^5.91.0"

--- a/src/components/ModalExample.tsx
+++ b/src/components/ModalExample.tsx
@@ -7,12 +7,13 @@ const ModalExample = () => {
   const { isModalOpen, openModal, closeModal } = useModal();
   // 모달 컴포넌트를 Modal 컴포넌트로 감싸고, isOpen과 closeModal을 props로 전달한다.
   // 모달 열림 버튼에 openModal 함수를 연결한다.
+  // 모달 컴포넌트에 className을 추가하여 모달의 추가적 클래스를 조절한다.
   return (
     <div>
       <button onClick={openModal} type="button" className="p-16 border-1">
         Open Modal
       </button>
-      <Modal isOpen={isModalOpen} closeModal={closeModal}>
+      <Modal isOpen={isModalOpen} closeModal={closeModal} modal="w-900">
         <EditInfo />
       </Modal>
     </div>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,19 +1,24 @@
 import { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 import ModalPortal from '@/utils/ModalPortal';
 
 type ModalProps = {
   isOpen: boolean;
   children: ReactNode;
   closeModal: () => void;
+  modal?: string;
 };
 
-const Modal = ({ isOpen, children, closeModal }: ModalProps) => {
+const Modal = ({ isOpen, children, closeModal, modal = '' }: ModalProps) => {
   if (!isOpen) {
     return null;
   }
 
-  const modalClass =
-    'flex flex-col fixed top-1/2 left-1/2  bg-white rounded-8 z-50 transform -translate-x-1/2 -translate-y-1/2 px-28 py-32';
+  const modalBasicClass = `flex flex-col fixed top-1/2 left-1/2 bg-white rounded-8 z-50 transform -translate-x-1/2 -translate-y-1/2 px-28 py-32 ${isOpen ? 'block' : ''}`;
+
+  const modalClass = twMerge(modalBasicClass, modal);
+
+  console.log(modalClass);
 
   return (
     <ModalPortal>
@@ -21,7 +26,7 @@ const Modal = ({ isOpen, children, closeModal }: ModalProps) => {
         className="fixed left-0 top-0 w-full h-full bg-black-modal"
         onClick={closeModal}
       />
-      <div className={`${modalClass} ${isOpen ? 'block' : ''}`}>{children}</div>
+      <div className={modalClass}>{children}</div>
     </ModalPortal>
   );
 };

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { twMerge } from 'tailwind-merge';
 import ModalPortal from '@/utils/ModalPortal';
 
@@ -10,15 +10,33 @@ type ModalProps = {
 };
 
 const Modal = ({ isOpen, children, closeModal, modal = '' }: ModalProps) => {
-  if (!isOpen) {
-    return null;
-  }
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+  }, [isOpen]);
 
   const modalBasicClass = `flex flex-col fixed top-1/2 left-1/2 bg-white rounded-8 z-50 transform -translate-x-1/2 -translate-y-1/2 px-28 py-32 ${isOpen ? 'block' : ''}`;
 
   const modalClass = twMerge(modalBasicClass, modal);
 
-  console.log(modalClass);
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeModal();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeModal]);
+
+  if (!isOpen) {
+    return null;
+  }
 
   return (
     <ModalPortal>


### PR DESCRIPTION
## 🚀 작업 내용

- [twMerge를 통한 모달의 동적 스타일 생성](https://github.com/sprint4-part4-team7/TravelPort-49105/commit/13399808ad405b16a89dca711ad0d733bbaeef3c)
- [모달 esc 닫기 기능, 모달 스크롤 방지 기능 추가](https://github.com/sprint4-part4-team7/TravelPort-49105/commit/d8e5e9194727fa287f4f6d36125c64f182e11da1)

## 📝 참고 사항

- tailwind css 클래스 병합을 위해 tailwind-merge 라이브러리를 추가했습니다
- 이로인한 npm install이 필요한 점 유의 바랍니다

## 🖼️ 스크린샷

## 🚨 관련 이슈
