### PR TITLE
[Refactor] 헤더바 수정 

### DIFF
--- a/src/components/common/headerBar/HeaderBar.tsx
+++ b/src/components/common/headerBar/HeaderBar.tsx
@@ -1,21 +1,49 @@
+/* eslint-disable no-undef */
 import React, { useState } from 'react';
 import LoginUserHeaderBar from './LoginUserHeaderBar';
 import UnLoginUserHeaderBar from './UnLoginUserHeaderBar';
+import SearchBar from '../SearchBar';
 
 interface HeaderBarProps {
   userType: 'user' | 'partner'; // 유저 타입: 'user' 혹은 'partner'
 }
 
+const cardLists = [
+  {
+    title: '스쿠버 다이빙',
+    description: '신나는 바닷속 체험',
+  },
+  {
+    title: '스쿠버플라잉',
+    description: '신나는 하늘 체험',
+  },
+];
+
 const HeaderBar: React.FC<HeaderBarProps> = ({ userType }) => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(true);
+  const [search, setSearch] = useState('');
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setSearch(e.target.value);
+
+  const filteredTitles = cardLists.filter((filteredTitle) => {
+    return filteredTitle.title
+      .replace(' ', '')
+      .toLowerCase()
+      .includes(search.trim().toLowerCase());
+  });
   return (
-    <div className="pb-[4.5rem]  text-2xl font-bold ">
+    <div className="pb-[4.5rem] text-2xl font-bold">
       <div className="flex items-center">
         <div className="flex-1 ">
           <div className="bg-pink-200 w-170 py-[1.5rem] px-[3.2rem]">LOGO</div>
         </div>
         <div className="flex-1 bg-[#F5F5F5]">
-          <div className="py-[1.5rem] px-[3.2rem]">서치바</div>
+          {/* <div className="py-[1.5rem] px-[3.2rem]">서치바</div> */}
+          <SearchBar
+            titles={filteredTitles}
+            search={search}
+            onChange={onChange}
+          />
         </div>
         <div className="flex-1" />
         <div className="flex justify-end flex-1 space-x-2">

--- a/src/components/common/headerBar/HeaderBar.tsx
+++ b/src/components/common/headerBar/HeaderBar.tsx
@@ -9,7 +9,7 @@ interface HeaderBarProps {
 const HeaderBar: React.FC<HeaderBarProps> = ({ userType }) => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(true);
   return (
-    <div className="py-[4.5rem] px-[3.6rem] text-2xl font-bold">
+    <div className="pb-[4.5rem]  text-2xl font-bold ">
       <div className="flex items-center">
         <div className="flex-1 ">
           <div className="bg-pink-200 w-170 py-[1.5rem] px-[3.2rem]">LOGO</div>

--- a/src/components/common/headerBar/HeaderBar.tsx
+++ b/src/components/common/headerBar/HeaderBar.tsx
@@ -31,14 +31,14 @@ const HeaderBar: React.FC<HeaderBarProps> = ({ userType }) => {
       .toLowerCase()
       .includes(search.trim().toLowerCase());
   });
+
   return (
-    <div className="pb-[4.5rem] text-2xl font-bold">
+    <div className="px-[3.6rem] fixed top-0 left-0 right-0 py-[4.5rem] text-2xl font-bold bg-white z-50">
       <div className="flex items-center">
-        <div className="flex-1 ">
+        <div className="flex-1">
           <div className="bg-pink-200 w-170 py-[1.5rem] px-[3.2rem]">LOGO</div>
         </div>
         <div className="flex-1 bg-[#F5F5F5]">
-          {/* <div className="py-[1.5rem] px-[3.2rem]">서치바</div> */}
           <SearchBar
             titles={filteredTitles}
             search={search}

--- a/src/components/common/headerBar/LoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/LoginUserHeaderBar.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
+import useOutsideClick from '@/hooks/useOutsideClick';
 
 interface LoginUserHeaderBarProps {
   setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
@@ -21,21 +22,7 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
     setIsDropdownOpen(!isDropdownOpen);
   };
 
-  const handleClickOutside = (event: MouseEvent) => {
-    if (
-      dropdownRef.current &&
-      !dropdownRef.current.contains(event.target as Node)
-    ) {
-      setIsDropdownOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+  useOutsideClick(dropdownRef, () => setIsDropdownOpen(false));
 
   const user: User = {
     name: '김짱구',

--- a/src/components/common/headerBar/LoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/LoginUserHeaderBar.tsx
@@ -45,13 +45,7 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
             path: '/reservation-history',
           },
         ]
-      : [
-          {
-            id: 'business-management',
-            label: '사업증 관리',
-            path: '/business-management',
-          },
-        ]),
+      : []),
     { id: 'logout', label: '로그아웃', action: () => setIsLoggedIn(false) },
   ];
 
@@ -69,11 +63,6 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
         />
       </button>
       <span>{user.name}</span>
-      {userType === 'user' && (
-        <button type="button" className="p-5 text-white bg-blue-500">
-          장바구니
-        </button>
-      )}
       {isDropdownOpen && (
         <div
           ref={dropdownRef}

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -1,13 +1,18 @@
 import React, { ReactNode } from 'react';
+import HeaderBar from '../headerBar/HeaderBar';
 
 interface LayoutProps {
   children: ReactNode;
+  userType: 'user' | 'partner';
 }
 
-const Layout: React.FC<LayoutProps> = ({ children }) => {
+const Layout: React.FC<LayoutProps> = ({ children, userType }) => {
   return (
-    <div className="px-[3.6rem] pb-[4.5rem] mt-[14.4rem] overflow-hidden break-words whitespace-normal">
-      {children}
+    <div>
+      <HeaderBar userType={userType} />
+      <div className="px-[3.6rem] pb-[4.5rem] mt-[14.4rem] overflow-hidden break-words whitespace-normal">
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -5,7 +5,11 @@ interface LayoutProps {
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
-  return <div className="px-[3.6rem] py-[4.5rem]">{children}</div>;
+  return (
+    <div className="px-[3.6rem] pb-[4.5rem] mt-[14.4rem] overflow-hidden break-words whitespace-normal">
+      {children}
+    </div>
+  );
 };
 
 export default Layout;

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -1,0 +1,11 @@
+import React, { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout: React.FC<LayoutProps> = ({ children }) => {
+  return <div className="px-[3.6rem] py-[4.5rem]">{children}</div>;
+};
+
+export default Layout;

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,18 @@
+import { useEffect, RefObject } from 'react';
+
+const useOutsideClick = (ref: RefObject<HTMLElement>, callback: () => void) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, callback]);
+};
+
+export default useOutsideClick;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,10 +1,8 @@
-import HeaderBar from '@/components/common/headerBar/HeaderBar';
 import Layout from '@/components/common/layout/Layout';
 
 const Main = () => {
   return (
-    <Layout>
-      <HeaderBar userType="user" />
+    <Layout userType="user">
       <h1 className="text-3xl font-bold underline">여긴메인페이지</h1>
     </Layout>
   );

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,11 +1,12 @@
 import HeaderBar from '@/components/common/headerBar/HeaderBar';
+import Layout from '@/components/common/layout/Layout';
 
 const Main = () => {
   return (
-    <div>
+    <Layout>
       <HeaderBar userType="user" />
       <h1 className="text-3xl font-bold underline">여긴메인페이지</h1>
-    </div>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## 🚀 작업 내용

- 추후 구현한다고 해서 장바구니 삭제했습니다.
- 파트너 헤더바 드롭다운에서 사업자 등록 삭제 했습니다.
- fixed사용해서 상단에 고정시켰습니다.
- SearchBar 삽입해놨습니다 !

- Layout 컴포넌트 생성 시켰습니다.

- useOutsideClick.ts 커스텀 훅 생성해놨습니다! 쓰실 분들은 쓰세용 ~

## 📝 참고 사항

- Layout 내부에 헤더바 삽입해놨기 때문에 여러분들 페이지에서는
```
<Layout userType="user">
      <h1 className="text-3xl font-bold underline">여긴메인페이지</h1>
      <p>여기에 내용 작성해주세요 ~~~~~~~</p>
</Layout>
```
이런식으로 작성해주시면 됩니다 ! 

## 🖼️ 스크린샷
<img width="1424" alt="스크린샷 2024-05-29 오후 1 24 44" src="https://github.com/sprint4-part4-team7/TravelPort-49105/assets/114905530/f0abfc38-bb44-4024-8cf8-c6f915ed3821">

## 🚨 관련 이슈

- close-#(issue_number)
