### PR TITLE
[Feat] calendar mockdata로 구현

### DIFF
--- a/src/components/common/CalendarCustom.css
+++ b/src/components/common/CalendarCustom.css
@@ -24,10 +24,13 @@
 
 .react-calendar__tile--now {
   background-color: yellow;
+  color: black;
 }
 
 .react-calendar__navigation button {
   border-radius: 99px;
+  min-width: 3.5rem;
+  height: 3.5rem;
 }
 
 .react-calendar__navigation button:disabled {

--- a/src/components/common/CalendarCustom.css
+++ b/src/components/common/CalendarCustom.css
@@ -1,0 +1,43 @@
+.react-calendar {
+  width: 100%;
+}
+
+.react-calendar__tile {
+  border-radius: 8px;
+  background-color: white;
+}
+
+.react-calendar__tile:disabled {
+  color: #afaeac;
+  background-color: white;
+}
+
+.react-calendar__tile:enabled:hover {
+  background-color: #cdd3f4;
+}
+
+.react-calendar__tile--active,
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background-color: #687bdf;
+}
+
+.react-calendar__tile--now {
+  background-color: yellow;
+}
+
+.react-calendar__navigation button {
+  border-radius: 99px;
+}
+
+.react-calendar__navigation button:disabled {
+  background-color: white;
+}
+
+.react-calendar__navigation button:enabled:focus {
+  background-color: white;
+}
+
+.react-calendar__navigation button:enabled:hover {
+  background-color: #8999e6;
+}

--- a/src/components/common/CalendarCustom.tsx
+++ b/src/components/common/CalendarCustom.tsx
@@ -10,6 +10,7 @@ interface CalendarCustomProps {
   endDate: Date;
   selectedDate: SelectedDate;
   setSelectedDate: React.Dispatch<React.SetStateAction<SelectedDate>>;
+  holiday: number[];
 }
 
 const CalendarCustom = ({
@@ -17,23 +18,31 @@ const CalendarCustom = ({
   endDate,
   selectedDate,
   setSelectedDate,
+  holiday,
 }: CalendarCustomProps) => {
+  const maxStartDate =
+    new Date().getTime() >= startDate.getTime() ? new Date() : startDate;
+  const minEndDate =
+    new Date().getTime() >= endDate.getTime() ? new Date() : endDate;
+
   return (
-    <div>
-      <Calendar
-        onChange={setSelectedDate}
-        value={selectedDate}
-        view="month"
-        calendarType="gregory"
-        showNeighboringMonth={false}
-        minDate={startDate}
-        maxDate={endDate}
-        tileDisabled={({ date, view }) =>
-          view === 'month' && date.getDay() === 0
-        }
-        formatDay={(_, date) => date.toLocaleString('en', { day: 'numeric' })}
-      />
-    </div>
+    <Calendar
+      onChange={setSelectedDate}
+      value={selectedDate}
+      view="month"
+      calendarType="gregory"
+      showNeighboringMonth={false}
+      minDate={maxStartDate}
+      maxDate={minEndDate}
+      tileDisabled={({ date, view }) => {
+        return (
+          holiday.length > 0 &&
+          view === 'month' &&
+          holiday.includes(date.getDay())
+        );
+      }}
+      formatDay={(_, date) => date.toLocaleString('en', { day: 'numeric' })}
+    />
   );
 };
 export default CalendarCustom;

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+type DatePiece = Date | null;
+type SelectedDate = DatePiece | [DatePiece, DatePiece];
+
+const useCalendar = () => {
+  const [selectedDate, setSelectedDate] = useState<SelectedDate>(new Date());
+
+  return {
+    selectedDate,
+    setSelectedDate,
+  };
+};
+
+export default useCalendar;

--- a/src/pages/Reservation.tsx
+++ b/src/pages/Reservation.tsx
@@ -1,26 +1,23 @@
-import { useState } from 'react';
+import useCalendar from '@/hooks/useCalendar';
 import CalendarCustom from '../components/common/CalendarCustom';
 
-type DatePiece = Date | null;
-type SelectedDate = DatePiece | [DatePiece, DatePiece];
-
 const Reservation = () => {
-  const [selectedDate, setSelectedDate] = useState<SelectedDate>(new Date());
-  console.log(selectedDate, setSelectedDate);
+  const { selectedDate, setSelectedDate } = useCalendar();
 
   const startDate = new Date(2024, 4, 4);
-  const maxStartDate =
-    new Date().getTime() >= startDate.getTime() ? new Date() : startDate;
   const endDate = new Date(2024, 7, 10);
-  const minEndDate =
-    new Date().getTime() >= endDate.getTime() ? new Date() : endDate;
+  const holiday = [0];
+
   return (
-    <CalendarCustom
-      startDate={maxStartDate}
-      endDate={minEndDate}
-      selectedDate={selectedDate}
-      setSelectedDate={setSelectedDate}
-    />
+    <div className="w-[30rem]">
+      <CalendarCustom
+        startDate={startDate}
+        endDate={endDate}
+        selectedDate={selectedDate}
+        setSelectedDate={setSelectedDate}
+        holiday={holiday}
+      />
+    </div>
   );
 };
 

--- a/src/pages/Reservation.tsx
+++ b/src/pages/Reservation.tsx
@@ -4,7 +4,9 @@ import CalendarCustom from '../components/common/CalendarCustom';
 const Reservation = () => {
   const { selectedDate, setSelectedDate } = useCalendar();
 
-  const startDate = new Date(2024, 4, 4);
+  const mockDate = '2024-05-27T03:05:19.935Z';
+  const dateArray = mockDate.split('T')[0].split('-').map(Number);
+  const startDate = new Date(dateArray[0], dateArray[1] - 1, dateArray[2]);
   const endDate = new Date(2024, 7, 10);
   const holiday = [0];
 

--- a/src/pages/Reservation.tsx
+++ b/src/pages/Reservation.tsx
@@ -8,7 +8,7 @@ const Reservation = () => {
   const dateArray = mockDate.split('T')[0].split('-').map(Number);
   const startDate = new Date(dateArray[0], dateArray[1] - 1, dateArray[2]);
   const endDate = new Date(2024, 7, 10);
-  const holiday = [0];
+  const holiday = ['0'].map(Number);
 
   return (
     <div className="w-[30rem]">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,8 +4,4 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer components {
-  .react-calendar {
-    @apply w-full;
-  }
-}
+@import url('../components/common/CalendarCustom.css');

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,6 @@
 
 @layer components {
   .react-calendar {
-    @apply w-500;
+    @apply w-full;
   }
 }


### PR DESCRIPTION
## 🚀 작업 내용

- useCalendar 훅으로 선택된 date를 받아올 수 있도록 했습니다.
- mockData로 받은 후 로직 구현했습니다.
- 캘린더 width는 CalendarCustom 컴포넌트를 감싼 태그에 설정해주시면 됩니다.

## 📝 참고 사항

- 디자인 임시로 설정했습니다.

## 🖼️ 스크린샷

https://github.com/sprint4-part4-team7/TravelPort-49105/assets/144013048/5daa0a5c-5796-41b1-86db-083fa0ca5db6

## 🚨 관련 이슈
