### PR TITLE
[Design] figma 시안에 포함된 color 변수 추가

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,9 +5,7 @@ const rem0_100 = { ...Array.from(Array(101)).map((_, i) => `${i / 10}rem`) };
 const rem0_1200 = { ...Array.from(Array(1201)).map((_, i) => `${i / 10}rem`) };
 
 module.exports = {
-  content: [
-    './src/**/*.{js,ts,jsx,tsx,mdx}',
-  ],
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {
       borderWidth: rem0_10,
@@ -18,9 +16,53 @@ module.exports = {
       minHeight: rem0_1200,
       spacing: rem0_1200,
       colors: {
+        white: '#ffffff',
         black: {
           modal: 'rgba(0, 0, 0, 0.5)',
-        }
+          1: '#ffffff',
+          2: '#fcfcfc',
+          3: '#f5f5f5',
+          4: '#f0f0f0',
+          5: '#d9d9d9',
+          6: '#bfbfbf',
+          7: '#8c8c8c',
+          8: '#595959',
+          9: '#454545',
+          10: '#262626',
+          11: '#1f1f1f',
+          12: '#141414',
+          13: '#000000',
+        },
+        blue: {
+          1: '#eaf0fd',
+          2: '#cddaf9',
+          3: '#a6bdf5',
+          4: '#7d9ef1',
+          5: '#5581ec',
+          6: '#3065e8',
+          7: '#2956c5',
+          8: '#2248a5',
+          9: '#1b3a84',
+          10: '#162d68',
+        },
+        system: {
+          success: '#52c41a',
+          'success-bg': '#cff2be',
+          warning: '#faad14',
+          'warning-bg': '#fbe2ae',
+          error: '#ff4d4f',
+          'error-bg': '#ffaeaf',
+          complete: '#1890ff',
+          'complete-bg': '#abd6fe',
+        },
+        secondary: {
+          magenta: '#ff35d3',
+          cyan: '#35ff92',
+          green: '#beff35',
+          red: '#ff3535',
+          orange: '#ff6635',
+          yellow: '#fbff35',
+        },
       },
       screens: {
         tablet: { max: '1199px' },


### PR DESCRIPTION
## 🚀 작업 내용

- figma 시안에 포함된 color 변수 추가
    - blue, black, system, secondary

## 📝 참고 사항

- black-1 변수의 경우 white(#ffffff) 변수와 같습니다.
    - 추후 black의 범위를 수정하거나 white 변수를 삭제하면 되겠습니다.

## 🖼️ 스크린샷

## 🚨 관련 이슈

- close-#(issue_number)
