### PR TITLE
[Feat, Api] Login, Signup 관련 API 함수 정의 파일 생성, 로그인 및 회원가입 페이지에 함수 적용

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,0 +1,69 @@
+import instance from '@/utils/axios';
+import { setCookie } from '@/utils/cookie';
+import axios from 'axios';
+
+type LoginForm = {
+  email: string;
+  password: string;
+};
+
+export const postLogin = async (data: LoginForm) => {
+  const { email, password } = data;
+  try {
+    const res = await instance.post('auth/user-login', {
+      email,
+      password,
+    });
+    const result = res.data;
+    const ACCESS_TOKEN = result.accessToken;
+    setCookie('accessToken', ACCESS_TOKEN);
+    axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
+  } catch (error: any) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      throw new Error(error.response.data.message);
+    } else if (axios.isAxiosError(error) && error.response?.status === 500) {
+      throw new Error(error.response.data.message);
+    } else {
+      throw new Error(error.message);
+    }
+  }
+};
+
+export const getGoogleLogin = async (code: string | null) => {
+  try {
+    const res = await instance.get(`auth/google/callback?code=${code}`);
+    const ACCESS_TOKEN = res.data.accessToken;
+    setCookie('accessToken', ACCESS_TOKEN);
+    axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 500) {
+      throw new Error(error.response.data.message);
+    }
+  }
+};
+
+export const getKakaoLogin = async (code: string | null) => {
+  try {
+    const res = await instance.get(`auth/kakao/callback?code=${code}`);
+    const ACCESS_TOKEN = res.data.accessToken;
+    setCookie('accessToken', ACCESS_TOKEN);
+    axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 500) {
+      throw new Error(error.response.data.message);
+    }
+  }
+};
+
+export const getNaverLogin = async (code: string | null) => {
+  try {
+    const res = await instance.get(`auth/naver/callback?code=${code}`);
+    const ACCESS_TOKEN = res.data.accessToken;
+    setCookie('accessToken', ACCESS_TOKEN);
+    axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 500) {
+      throw new Error(error.response.data.message);
+    }
+  }
+};

--- a/src/apis/signup.ts
+++ b/src/apis/signup.ts
@@ -1,0 +1,68 @@
+import instance from '@/utils/axios';
+import axios from 'axios';
+
+interface UserSignupData {
+  nickname: string;
+  email: string;
+  password: string;
+}
+
+interface PartnerSignupData {
+  company: string;
+  email: string;
+  password: string;
+}
+
+export const postVerifyEmail = async (email: string) => {
+  try {
+    const res = await instance.post('/auth/valid-email', { email });
+    const result = res.data;
+    return result;
+  } catch (error: any) {
+    if (axios.isAxiosError(error) && error.response?.status === 400) {
+      throw new Error(error.response.data.message);
+    } else {
+      throw new Error(error.message);
+    }
+  }
+};
+
+export const postUserSignup = async (data: UserSignupData) => {
+  const { nickname, email, password } = data;
+  try {
+    const res = await instance.post('/auth/user-signup', {
+      nickname,
+      email,
+      password,
+    });
+    const result = res.data;
+    return result;
+  } catch (error: any) {
+    if (axios.isAxiosError(error) && error.response?.status === 400) {
+      throw new Error(error.response.data.message);
+    } else {
+      throw new Error(error.message);
+    }
+  }
+};
+
+// 현재 Swagger에는 /auth/partner-signup이 없음
+// 추가 뒤 사용 권장
+export const postPartnerSignup = async (data: PartnerSignupData) => {
+  const { company, email, password } = data;
+  try {
+    const res = await instance.post('/auth/partner-signup', {
+      company,
+      email,
+      password,
+    });
+    const result = res.data;
+    return result;
+  } catch (error: any) {
+    if (axios.isAxiosError(error) && error.response?.status === 400) {
+      throw new Error(error.response.data.message);
+    } else {
+      throw new Error(error.message);
+    }
+  }
+};

--- a/src/pages/auth/login/GoogleRedirect.tsx
+++ b/src/pages/auth/login/GoogleRedirect.tsx
@@ -1,6 +1,4 @@
-import instance from '@/utils/axios';
-import { setCookie } from '@/utils/cookie';
-import axios from 'axios';
+import { getGoogleLogin } from '@/apis/login';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -9,18 +7,11 @@ const GoogleRedirect = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // back-end로 인가 코드 전달
-    const GoogleLogin = async () => {
-      try {
-        const res = await instance.get(`auth/google/callback?code=${code}`);
-        const ACCESS_TOKEN = res.data.accessToken;
-        setCookie('accessToken', ACCESS_TOKEN);
-        axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
-      } catch (error) {
-        console.error('Error:', error);
-      }
-    };
-    GoogleLogin();
+    try {
+      getGoogleLogin(code);
+    } catch (error: any) {
+      alert(error.message);
+    }
     navigate('/', { replace: true });
   }, [code]);
 

--- a/src/pages/auth/login/KakaoRedirect.tsx
+++ b/src/pages/auth/login/KakaoRedirect.tsx
@@ -1,6 +1,4 @@
-import instance from '@/utils/axios';
-import { setCookie } from '@/utils/cookie';
-import axios from 'axios';
+import { getKakaoLogin } from '@/apis/login';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,17 +8,11 @@ const KakaoRedirect = () => {
 
   useEffect(() => {
     // back-end로 인가 코드 전달
-    const KakaoLogin = async () => {
-      try {
-        const res = await instance.get(`auth/kakao/callback?code=${code}`);
-        const ACCESS_TOKEN = res.data.accessToken;
-        setCookie('accessToken', ACCESS_TOKEN);
-        axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
-      } catch (error) {
-        console.error('Error:', error);
-      }
-    };
-    KakaoLogin();
+    try {
+      getKakaoLogin(code);
+    } catch (error: any) {
+      alert(error.message);
+    }
     navigate('/', { replace: true });
   }, [code]);
 

--- a/src/pages/auth/login/Login.tsx
+++ b/src/pages/auth/login/Login.tsx
@@ -6,9 +6,7 @@ import useOAuthLogin from '@/hooks/useOAuthLogin';
 import { useForm } from 'react-hook-form';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
-import instance from '@/utils/axios';
-import { setCookie } from '@/utils/cookie';
-import axios from 'axios';
+import { postLogin } from '@/apis/login';
 import Button from '@/components/common/Button';
 import InputBox from '@/components/common/InputBox';
 
@@ -29,19 +27,11 @@ const Login = () => {
   const navigate = useNavigate();
 
   const handleLoginForm = async (data: LoginForm) => {
-    const { email, password } = data;
     try {
-      const res = await instance({
-        url: 'auth/user-login',
-        method: 'POST',
-        data: { email, password },
-      });
-      const ACCESS_TOKEN = res.data.accessToken;
-      setCookie('accessToken', ACCESS_TOKEN);
-      axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
+      await postLogin(data);
       navigate('/', { replace: true });
     } catch (error: any) {
-      console.log(error.message);
+      alert(error.message);
     }
   };
 

--- a/src/pages/auth/login/NaverRedirect.tsx
+++ b/src/pages/auth/login/NaverRedirect.tsx
@@ -1,6 +1,4 @@
-import instance from '@/utils/axios';
-import { setCookie } from '@/utils/cookie';
-import axios from 'axios';
+import { getNaverLogin } from '@/apis/login';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -9,18 +7,11 @@ const NaverRedirect = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // back-end로 인가 코드 전달
-    const NaverLogin = async () => {
-      try {
-        const res = await instance.get(`auth/naver/callback?code=${code}`);
-        const ACCESS_TOKEN = res.data.accessToken;
-        setCookie('accessToken', ACCESS_TOKEN);
-        axios.defaults.headers.common.Authorization = `Bearer ${ACCESS_TOKEN}`;
-      } catch (error) {
-        console.error('Error:', error);
-      }
-    };
-    NaverLogin();
+    try {
+      getNaverLogin(code);
+    } catch (error: any) {
+      alert(error.message);
+    }
     navigate('/', { replace: true });
   }, [code]);
 

--- a/src/pages/auth/signup/PartnerSignup.tsx
+++ b/src/pages/auth/signup/PartnerSignup.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
-import instance from '@/utils/axios';
+import { postPartnerSignup, postVerifyEmail } from '@/apis/signup';
 import Button from '@/components/common/Button';
 import InputBox from '@/components/common/InputBox';
 
@@ -47,22 +47,10 @@ const PartnerSignup = () => {
 
   const handleCheckEmail = async () => {
     const email = watch('email');
-    setIsEmailValid(false);
     try {
-      const res = await instance({
-        url: '/auth/valid-email',
-        method: 'POST',
-        data: {
-          email,
-        },
-      });
-      if (res.data.result) {
-        setIsEmailValid(res.data.result);
-        setEmailMessage(res.data.message);
-      } else {
-        setIsEmailValid(res.data.result);
-        setEmailMessage(res.data.message);
-      }
+      const data = await postVerifyEmail(email);
+      setIsEmailValid(data.result);
+      setEmailMessage(data.message);
     } catch (e: any) {
       setIsEmailValid(false);
       setEmailMessage(e.message);
@@ -70,22 +58,13 @@ const PartnerSignup = () => {
   };
 
   const handleSignupForm = async (data: PartnerSignupData) => {
-    const { company, email, password } = data;
     try {
-      await instance({
-        url: 'auth/partner-signup',
-        method: 'POST',
-        data: {
-          company,
-          email,
-          password,
-        },
-      });
+      await postPartnerSignup(data);
       if (isEmailValid) {
         navigate('/login', { replace: true });
       }
     } catch (e: any) {
-      console.log(0);
+      alert(e.message);
     }
   };
 

--- a/src/pages/auth/signup/UserSignup.tsx
+++ b/src/pages/auth/signup/UserSignup.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
-import instance from '@/utils/axios';
+import { postUserSignup, postVerifyEmail } from '@/apis/signup';
 import Button from '@/components/common/Button';
 import InputBox from '@/components/common/InputBox';
 
@@ -47,20 +47,9 @@ const UserSignup = () => {
   const handleCheckEmail = async () => {
     const email = watch('email');
     try {
-      const res = await instance({
-        url: '/auth/valid-email',
-        method: 'POST',
-        data: {
-          email,
-        },
-      });
-      if (res.data.result) {
-        setIsEmailValid(res.data.result);
-        setEmailMessage(res.data.message);
-      } else {
-        setIsEmailValid(res.data.result);
-        setEmailMessage(res.data.message);
-      }
+      const data = await postVerifyEmail(email);
+      setIsEmailValid(data.result);
+      setEmailMessage(data.message);
     } catch (e: any) {
       setIsEmailValid(false);
       setEmailMessage(e.message);
@@ -68,23 +57,13 @@ const UserSignup = () => {
   };
 
   const handleSignupForm = async (data: UserSignupData) => {
-    const { nickname, email, password } = data;
     try {
-      await instance({
-        url: 'auth/user-signup',
-        method: 'POST',
-        data: {
-          nickname,
-          email,
-          password,
-        },
-      });
-      console.log(isEmailValid);
+      await postUserSignup(data);
       if (isEmailValid) {
         navigate('/login', { replace: true });
       }
     } catch (e: any) {
-      console.log(0);
+      alert(e.message);
     }
   };
 


### PR DESCRIPTION
## 🚀 작업 내용

- apiSample.ts 파일 삭제
- login.ts 파일 생성 및 로그인 api 관련 함수 정의
    - POST : 이메일로 로그인 api 함수 정의(postLogin)
    - GET : google, kakao, naver 소셜 로그인 api  함수정의(getGoogleLogin, getKakaoLogin, getNaverLogin)
    - 페이지 적용 : Login.tsx, 소셜 로그인 별 리다이렉트 페이지
- signup.ts 파일 생성 및 회원가입 api 관련 함수 정의
    - POST : 이메일 중복 체크 api 함수 정의(postVerifyEmail)
    - POST : 일반 유저, 파트너 유저 회원가입 api 함수 정의(postUserSignup, postPartnerSignup)
    - 페이지 적용 : UserSignup.tsx, PartnerSignup.tsx

## 📝 참고 사항

- 파트너 회원가입의 경우 (/auth/partner-signup) 류의 api가 구현되지 않았기 때문에 파트너 회원가입은 api 구현 전까지는 사용을 피해주시기 바랍니다.

## 🖼️ 스크린샷

**<이메일 중복체크>**
![Untitled (6)](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/80890af3-b26b-4204-b840-cd276a51d8fe)
![Untitled (5)](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/c191707d-a108-45b7-aa63-e26d2d5249c2)


## 🚨 관련 이슈

- close-#(issue_number)
