### PR TITLE
[Fix, Design] 공통 Button 컴포넌트 디자인 추가 변경, Button 컴포넌트 적용(로그인, 회원가입, 메인페이지(Header, Carousel))

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -5,6 +5,7 @@
 /* eslint-disable no-undef */
 import React from 'react';
 import useCarousel from '@/hooks/useCarousel';
+import Button from '@/components/common/Button';
 
 interface CarouselItem {
   url: string;
@@ -43,19 +44,17 @@ const Carousel: React.FC<CarouselProps> = ({ items }) => {
             >
               <div className="relative w-full h-full">
                 <div className="absolute top-0 left-0 flex justify-center w-1/4 h-full text-white transform -translate-y-1 bg-gray-900 bg-opacity-50">
-                  <p className="text-[3.6rem] text-white py-[8rem] px-[4.8rem]">
-                    {item.text}
-                  </p>
+                  <p className="text-36 text-white py-80 px-48">{item.text}</p>
                 </div>
-                <div className="absolute bottom-[4.5rem] right-0 flex items-end justify-center w-[27.7rem] h-[2.2rem] text-white ">
-                  <button
+                <div className="absolute bottom-30 right-15 flex items-end justify-center w-300 h-22">
+                  <Button
+                    variant="floating"
+                    buttonStyle="px-40 py-18 text-24 font-semibold"
+                    text="지금 바로 예약하기! >"
                     onClick={() =>
                       item.path ? (window.location.href = item.path) : null
                     }
-                    className="text-2xl px-[4.4rem] py-[1.7rem] text-white bg-[#3F57D6] rounded-[1.2rem] font-semibold  "
-                  >
-                    지금 바로 예약하기! &gt;
-                  </button>
+                  />
                 </div>
               </div>
             </div>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,27 +1,34 @@
 type ButtonProps = {
-  variant?: 'default' | 'cancel';
+  variant?: 'default' | 'outlined' | 'more' | 'floating';
+  buttonStyle?: string; // font 굵기, text 크기, padding, width 변경 시
   text: string;
+  isCancel?: boolean;
   onClick?: () => void;
   disabled?: boolean;
 };
 
 const Button = ({
   variant = 'default',
+  buttonStyle = 'text-16 p-12 w-full',
   text = '',
+  isCancel = false,
   onClick,
   disabled = false,
 }: ButtonProps) => {
-  const buttonBasic =
-    'flex justify-center items-center p-10 rounded text-16 font-bold';
+  const basic = `flex justify-center items-center rounded ${buttonStyle}`;
+  const default = 'bg-blue-6 hover:bg-blue-5 active:bg-blue-7 text-white';
+  const outlined =
+    'bg-white border-1 border-solid border-blue-6 text-blue-6 hover:border-blue-5 hover:text-blue-5 active:border-blue-7 active:text-blue-7 ';
+
   const disabledDesign = 'bg-black-4 text-black-6';
   const cancelDesign = 'bg-black-4 text-black-12';
 
-  let buttonClass = `${buttonBasic} bg-blue-6 hover:bg-blue-5 active:bg-blue-7 text-white`;
+  let buttonClass = `${basic} bg-blue-6 hover:bg-blue-5 active:bg-blue-7 text-white`;
 
   if (disabled) {
-    buttonClass = `${buttonBasic} ${disabledDesign}`;
+    buttonClass = `${basic} ${disabledDesign}`;
   } else if (variant === 'cancel') {
-    buttonClass = `${buttonBasic} ${cancelDesign}`;
+    buttonClass = `${basic} ${cancelDesign}`;
   }
 
   return (

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -11,14 +11,14 @@ type ButtonProps = {
 const Button = ({
   variant = 'default',
   outlined = false,
-  buttonStyle = '',
+  buttonStyle = 'text-16 p-12',
   text = '',
   onClick,
   isCancel = false,
   disabled = false,
 }: ButtonProps) => {
   const styles = {
-    base: `${buttonStyle} flex justify-center items-center text-16 p-12 w-full rounded`,
+    base: `flex justify-center items-center w-full rounded ${buttonStyle}`,
     default: 'bg-blue-6 text-white hover:bg-blue-5 active:bg-blue-7',
     outlined:
       'bg-white border-1 border-solid border-blue-6 text-blue-6 hover:border-blue-5 hover:text-blue-5 active:border-blue-7 active:text-blue-7',

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,39 +1,59 @@
 type ButtonProps = {
-  variant?: 'default' | 'outlined' | 'more' | 'floating';
-  buttonStyle?: string; // font 굵기, text 크기, padding, width 변경 시
+  variant?: 'default' | 'more' | 'floating';
+  outlined?: boolean;
+  buttonStyle?: string; // font 굵기, text 크기, padding, width 변경 시 tailwind 형식으로 진행
   text: string;
-  isCancel?: boolean;
   onClick?: () => void;
+  isCancel?: boolean;
   disabled?: boolean;
 };
 
 const Button = ({
   variant = 'default',
-  buttonStyle = 'text-16 p-12 w-full',
+  outlined = false,
+  buttonStyle = '',
   text = '',
-  isCancel = false,
   onClick,
+  isCancel = false,
   disabled = false,
 }: ButtonProps) => {
-  const basic = `flex justify-center items-center rounded ${buttonStyle}`;
-  const default = 'bg-blue-6 hover:bg-blue-5 active:bg-blue-7 text-white';
-  const outlined =
-    'bg-white border-1 border-solid border-blue-6 text-blue-6 hover:border-blue-5 hover:text-blue-5 active:border-blue-7 active:text-blue-7 ';
+  const styles = {
+    base: `${buttonStyle} flex justify-center items-center text-16 p-12 w-full rounded`,
+    default: 'bg-blue-6 text-white hover:bg-blue-5 active:bg-blue-7',
+    outlined:
+      'bg-white border-1 border-solid border-blue-6 text-blue-6 hover:border-blue-5 hover:text-blue-5 active:border-blue-7 active:text-blue-7',
+    more: 'px-12 py-8 border-1 border-solid border-black-5 text-black-5 hover:bg-black-2 active:bg-black-3',
+    floating: 'rounded-28',
+    disabledDefault: 'bg-black-4 text-black-6',
+    disabledOutlined:
+      'bg-white border-1 border-solid border-black-4 text-black-6',
+    cancelDefault:
+      'bg-black-4 text-black-12 hover:bg-black-3 active:bg-black-5',
+    cancelOutlined:
+      'bg-white border-1 border-solid border-black-5 text-black-7 hover:border-black-6 hover:text-black-6 active:border-black-7 active:text-black-8',
+  };
 
-  const disabledDesign = 'bg-black-4 text-black-6';
-  const cancelDesign = 'bg-black-4 text-black-12';
-
-  let buttonClass = `${basic} bg-blue-6 hover:bg-blue-5 active:bg-blue-7 text-white`;
-
-  if (disabled) {
-    buttonClass = `${basic} ${disabledDesign}`;
-  } else if (variant === 'cancel') {
-    buttonClass = `${basic} ${cancelDesign}`;
-  }
+  const getButtonClass = () => {
+    if (disabled) {
+      return outlined ? styles.disabledOutlined : styles.disabledDefault;
+    }
+    if (isCancel) {
+      return outlined ? styles.cancelOutlined : styles.cancelDefault;
+    }
+    if (variant === 'more') {
+      return styles.more;
+    }
+    if (variant === 'floating') {
+      return outlined
+        ? `${styles.outlined} ${styles.floating}`
+        : `${styles.default} ${styles.floating}`;
+    }
+    return outlined ? styles.outlined : styles.default;
+  };
 
   return (
     <button
-      className={buttonClass}
+      className={`${styles.base} ${getButtonClass()}`}
       type="button"
       onClick={onClick}
       disabled={disabled}

--- a/src/components/common/headerBar/UnLoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/UnLoginUserHeaderBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import menu from '@/assets/icons/menu.svg';
+import Button from '@/components/common/Button';
 
 const UnLoginUserHeaderBar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -12,51 +13,50 @@ const UnLoginUserHeaderBar = () => {
       {/* 모바일 환경에서만 햄버거 아이콘 표시 */}
       <div className="hidden mobile:flex">
         <button type="button" onClick={() => setIsMenuOpen(!isMenuOpen)}>
-          <img className="h-[3.2rem] w-[3.2rem]" src={menu} alt="Menu" />
+          <img className="h-32 w-32" src={menu} alt="Menu" />
         </button>
       </div>
 
       {/* 드롭다운 메뉴 */}
       {isMenuOpen && (
-        <div className="absolute right-[-5rem] z-50 flex-col items-start justify-start hidden p-4 bg-white w-[15rem] top-full mobile:flex rounded-5">
-          <button
-            type="button"
-            className="box-border border-1 border-[#356EFF] border-solid p-[0.75rem] rounded-4 text-[#356EFF] text-[1.4rem] font-semibold leading-[142%] mb-4 w-full text-left"
+        <div className="absolute -right-50 z-50 flex-col gap-5 items-start justify-start hidden p-4 bg-white w-150 top-full mobile:flex rounded">
+          <Button
+            outlined
+            buttonStyle="text-14 p-8 font-semibold"
+            text="파트너 페이지"
             onClick={() => {
               navigate('./partner');
               setIsMenuOpen(false);
             }}
-          >
-            파트너 페이지
-          </button>
-          <button
-            type="button"
-            className="bg-[#356EFF] text-white p-[0.85rem] rounded-4 text-[1.4rem] font-semibold leading-[142%] w-full text-left"
+          />
+          <Button
+            buttonStyle="text-14 p-8 font-semibold"
+            text="로그인 및 회원가입"
             onClick={() => {
               navigate('./login');
               setIsMenuOpen(false);
             }}
-          >
-            로그인 및 회원가입
-          </button>
+          />
         </div>
       )}
 
       {/* 태블릿 및 PC 환경에서 회원가입 / 로그인 버튼들 표시 */}
-      <div className=" mobile:hidden space-x-[1.2rem]">
-        <button
-          type="button"
-          className="box-border border-1 border-[#356EFF] border-solid p-[0.75rem] rounded-4 text-[#356EFF] text-[1.4rem] font-semibold leading-[142%]"
-        >
-          파트너 페이지
-        </button>
-        <button
-          type="button"
-          className="bg-[#356EFF] text-white p-[0.85rem] rounded-4 text-[1.4rem] font-semibold leading-[142%]"
-          onClick={() => navigate('./login')}
-        >
-          로그인 및 회원가입
-        </button>
+      <div className="flex mobile:hidden space-x-12">
+        <Button
+          outlined
+          buttonStyle="min-w-fit text-14 p-10 font-semibold"
+          text="파트너 페이지"
+          onClick={() => {
+            navigate('./partner');
+          }}
+        />
+        <Button
+          buttonStyle="min-w-fit text-14 p-10 font-semibold"
+          text="로그인 및 회원가입"
+          onClick={() => {
+            navigate('./login');
+          }}
+        />
       </div>
     </div>
   );

--- a/src/pages/auth/login/Login.tsx
+++ b/src/pages/auth/login/Login.tsx
@@ -81,6 +81,7 @@ const Login = () => {
               })}
             />
             <Button
+              buttonStyle="font-semibold"
               text="로그인 하기"
               onClick={handleSubmit(handleLoginForm)}
             />

--- a/src/pages/auth/login/Login.tsx
+++ b/src/pages/auth/login/Login.tsx
@@ -81,7 +81,7 @@ const Login = () => {
               })}
             />
             <Button
-              buttonStyle="font-semibold"
+              buttonStyle="p-12 text-16 font-semibold"
               text="로그인 하기"
               onClick={handleSubmit(handleLoginForm)}
             />

--- a/src/pages/auth/signup/PartnerSignup.tsx
+++ b/src/pages/auth/signup/PartnerSignup.tsx
@@ -158,6 +158,7 @@ const PartnerSignup = () => {
               })}
             />
             <Button
+              buttonStyle="font-semibold"
               text="회원가입 하기"
               onClick={handleSubmit(handleSignupForm)}
             />

--- a/src/pages/auth/signup/PartnerSignup.tsx
+++ b/src/pages/auth/signup/PartnerSignup.tsx
@@ -158,7 +158,7 @@ const PartnerSignup = () => {
               })}
             />
             <Button
-              buttonStyle="font-semibold"
+              buttonStyle="p-12 text-16 font-semibold"
               text="회원가입 하기"
               onClick={handleSubmit(handleSignupForm)}
             />

--- a/src/pages/auth/signup/UserSignup.tsx
+++ b/src/pages/auth/signup/UserSignup.tsx
@@ -160,7 +160,7 @@ const UserSignup = () => {
               })}
             />
             <Button
-              buttonStyle="font-semibold"
+              buttonStyle="p-12 text-16 font-semibold"
               text="회원가입 하기"
               onClick={handleSubmit(handleSignupForm)}
             />

--- a/src/pages/auth/signup/UserSignup.tsx
+++ b/src/pages/auth/signup/UserSignup.tsx
@@ -160,6 +160,7 @@ const UserSignup = () => {
               })}
             />
             <Button
+              buttonStyle="font-semibold"
               text="회원가입 하기"
               onClick={handleSubmit(handleSignupForm)}
             />


### PR DESCRIPTION
## 🚀 작업 내용

- Figma 시안에 추가 및 변경된 Button 컴포넌트 내용 반영
    - 기존에 정의한 Button 컴포넌트 Props 정의 변경
    - default 디자인, outlined, floating, 더보기 디자인 구성
- 로그인, 회원가입(유저, 파트너-중복체크 제외), 메인 페이지에 사용되는 Button 요소 -> Button 컴포넌트 적용
- Carousel.tsx, UnLoginUserHeaderBar.tsx에서 사용되던 rem 단위 변경
    - 기존 `p-[x rem]` -> `p-x`형식으로 변경

## 📝 참고 사항

- figma 시안에 제시된 내용 이외에 hover, active 등의 동작 부분에서 추가할만한 내용은 추가하였습니다.
- buttonStyle props 값은 tailwind 형식으로 사용하실 수 있습니다.
- (주의) 버튼 스타일 수정 시(buttonStyle 사용 시), font 굵기, padding, text 크기를 설정 해주셔야 합니다.
    - buttonStyle='font-bold' 식으로 사용할 경우, padding, text가 시스템 기본값으로 설정 되기 때문에 font만 변경하더라도 font와 함께 padding, text 값을 추가하셔야합니다.

## 🖼️ 스크린샷
**<수정된 버튼 구성>**
![버튼 수정](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/b25324a6-b02e-4ee8-8a9c-c6969cef1c6d)

**<HeaderBar(Mobile)>**
![스크린샷 2024-06-04 165417](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/0bdddadb-baf8-4ca7-a29e-0130b8a3904e)


**<HeaderBar(PC, Tablet)>**
![스크린샷 2024-06-04 165433](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/88d9288b-0042-471e-90ad-0d024010ad58)


**<Carousel>**
![스크린샷 2024-06-04 165235](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/d3a16b41-2ece-43f3-b40c-515d2b0b204c)

## 🚨 관련 이슈

- close-#(issue_number)
