### PR TITLE
[Feat] 메인 페이지 api 연결

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -45,9 +45,6 @@ const Carousel: React.FC<CarouselProps> = ({ items }) => {
               }}
             >
               <div className="relative w-full h-full">
-                <div className="absolute top-0 left-0 flex justify-center w-1/4 h-full text-white transform -translate-y-1 bg-gray-900 bg-opacity-50">
-                  <p className="px-48 text-white text-36 py-80">{item.text}</p>
-                </div>
                 <div className="absolute left-0 right-0 flex items-center justify-center m-auto bottom-41 w-300 h-22">
                   <Button
                     variant="default"

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -40,18 +40,19 @@ const MainCard: React.FC<PopularAccommodationsProps> = ({
         </div>
       </div>
       <div className="grid gap-20 mobile:grid-cols-1 tablet:grid-cols-3 desktop:grid-cols-4">
-        {images.map((item, index) => (
-          <Card
-            key={index}
-            title={item.text as string}
-            location={item.location as string}
-            price={item.price as number}
-            score={item.score as number}
-            review={item.review as number}
-            image={item.url as string}
-            link={item.path as string}
-          />
-        ))}
+        {images &&
+          images.map((item, index) => (
+            <Card
+              key={index}
+              title={item.text as string}
+              location={item.location as string}
+              price={item.price as number}
+              score={item.score as number}
+              review={item.review as number}
+              image={item.url as string}
+              link={item.path as string}
+            />
+          ))}
       </div>
     </div>
   );

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -28,14 +28,14 @@ const MainCard: React.FC<PopularAccommodationsProps> = ({
     <div className="">
       <div className="flex justify-between mb-18">
         <p className="font-semibold text-22 ">{title} </p>
-        <div>
+        <div className="w-61">
           <Button
             variant="default"
             text="더보기"
             outlined
             isCancel
             onClick={onclick}
-            buttonStyle="rounded-4 px-12 py-8 w-61 text-13 font-medium text-[#BFBFBF]"
+            buttonStyle="rounded-4 px-12 py-8 text-13 font-medium text-black-5"
           />
         </div>
       </div>

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -28,14 +28,16 @@ const MainCard: React.FC<PopularAccommodationsProps> = ({
     <div className="">
       <div className="flex justify-between mb-18">
         <p className="font-semibold text-22 ">{title} </p>
-        <Button
-          variant="default"
-          text="더보기"
-          outlined
-          isCancel
-          onClick={onclick}
-          buttonStyle="rounded-4 px-12 py-8 w-61 text-13 font-medium text-[#BFBFBF]"
-        />
+        <div>
+          <Button
+            variant="default"
+            text="더보기"
+            outlined
+            isCancel
+            onClick={onclick}
+            buttonStyle="rounded-4 px-12 py-8 w-61 text-13 font-medium text-[#BFBFBF]"
+          />
+        </div>
       </div>
       <div className="grid gap-20 mobile:grid-cols-1 tablet:grid-cols-3 desktop:grid-cols-4">
         {images.map((item, index) => (

--- a/src/components/common/headerBar/HeaderBar.tsx
+++ b/src/components/common/headerBar/HeaderBar.tsx
@@ -27,14 +27,14 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
   const navigate = useNavigate();
   // TODO: 경로 맞게 수정하기 (지금은 임시 ..)
   const handleAccommodation = () => {
-    navigate('./list');
+    navigate('/list/3');
   };
   const handleActivity = () => {
-    navigate('./list');
+    navigate('/list/20');
   };
   // TODO: 교통 LIST 페이지로 가면 "서비스가 준비중입니다" 나오게 하기
   const handleTraffic = () => {
-    navigate('./list');
+    navigate('/list');
   };
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(true);
 

--- a/src/hooks/useFilterByCategory.ts
+++ b/src/hooks/useFilterByCategory.ts
@@ -1,0 +1,27 @@
+const useFilterByCategory = (data: any) => {
+  const categoryAccommodation =
+    data && data.filter((item: any) => item.categoryId === 3);
+  const categoryActivity =
+    data && data.filter((item: any) => item.categoryId === 20);
+
+  // 리뷰 개수가 3개 이상인 항목만 필터링하고 별점이 높은 순으로 정렬하는 함수
+  const filterAndSortByReviews = (items: any) => {
+    return (
+      items &&
+      items
+        .filter((item: any) => item.reviewCount >= 3) // 리뷰 개수가 3개 이상인 항목만 필터링
+        .sort((a: any, b: any) => b.averageScore - a.averageScore)
+    ); // 별점이 높은 순으로 정렬
+  };
+
+  // 카테고리 별로 필터링된 항목들 중 리뷰 개수가 3개 이상인 항목들을 별점 높은 순으로 정렬
+  const sortedCategoryAccommodation = filterAndSortByReviews(
+    categoryAccommodation,
+  );
+  const sortedCategoryActivity = filterAndSortByReviews(categoryActivity);
+
+  // 정렬된 항목들 반환
+  return { sortedCategoryAccommodation, sortedCategoryActivity };
+};
+
+export default useFilterByCategory;

--- a/src/hooks/useProductOptionsReviews.ts
+++ b/src/hooks/useProductOptionsReviews.ts
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+
+const useProductOptionsReviews = (
+  productAll: any,
+  optionAll: any,
+  reviewAll: any,
+) => {
+  return useMemo(() => {
+    const products = productAll.data;
+    return (
+      products &&
+      products
+        .map((product: any) => {
+          // 해당 제품의 옵션 찾기
+          const productOptions = optionAll.filter(
+            (option: any) => option.productId === product.id,
+          );
+
+          // 해당 옵션들의 리뷰 찾기
+          const reviews = reviewAll.filter((review: any) =>
+            productOptions.some(
+              (option: any) => option.id === review.productOptionId,
+            ),
+          );
+
+          // 리뷰 개수
+          const reviewCount = reviews.length;
+          // 평균 점수 계산
+          const averageScore =
+            Math.round(
+              (reviews.reduce((acc: any, curr: any) => acc + curr.score, 0) /
+                reviewCount) *
+                10,
+            ) / 10 || 0;
+
+          // 최저 가격 계산
+          const minPrice = productOptions.reduce((min: any, option: any) => {
+            return option.optionPrice < min ? option.optionPrice : min;
+          }, Infinity);
+
+          // 제품 객체에 리뷰 정보 및 최저 가격 추가
+          return { ...product, reviewCount, averageScore, minPrice };
+        })
+        .sort(
+          (a: any, b: any) =>
+            b.averageScore - a.averageScore || b.reviewCount - a.reviewCount,
+        )
+    ); // 평균 점수로 내림차순 정렬 후, 같으면 리뷰 개수로 내림차순 정렬
+  }, [productAll, optionAll, reviewAll]);
+};
+
+export default useProductOptionsReviews;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -49,11 +49,13 @@ const Main = () => {
   const navigate = useNavigate();
   const { productAll, optionAll } = useProductAll();
   const { data: reviewAll } = useReviewAllQuery();
+  // 카드에 들어가는 데이터
   const combinedData = useProductOptionsReviews(
     productAll,
     optionAll,
     reviewAll,
   );
+  // 카테고리로 분류
   const { sortedCategoryAccommodation, sortedCategoryActivity } =
     useFilterByCategory(combinedData);
 

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,15 +1,18 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-return-assign */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable react/no-array-index-key */
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import useProductAll from '@/hooks/useProductAll';
+import useReviewAllQuery from '@/hooks/reactQuery/review/useReviewAllQuery';
+import useProductOptionsReviews from '@/hooks/useProductOptionsReviews';
+import useFilterByCategory from '@/hooks/useFilterByCategory';
 import Carousel from '@/components/Carousel';
 import Footer from '@/components/common/Footer';
 import Layout from '@/components/common/layout/Layout';
 import MainCard from '@/components/MainCard';
-
-// TODO: 카테고리가 숙소인 후기높은? 별점많은? api 불러오기
-// TODO: 카테고리가 액티비티인 후기높은? 별점많은? api 불러오기
 
 interface ImageItem {
   url: string;
@@ -42,73 +45,70 @@ const carousel: ImageItem[] = [
   },
 ];
 
-const datas: ImageItem[] = [
-  {
-    url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIALcAxAMBIgACEQEDEQH/xAAaAAADAQEBAQAAAAAAAAAAAAACAwQAAQcG/8QAGRABAQEBAQEAAAAAAAAAAAAAAAIBAxIR/8QAGwEAAgMBAQEAAAAAAAAAAAAAAgMAAQQFBwb/xAAcEQEBAQADAQEBAAAAAAAAAAAAAQIDERITITH/2gAMAwEAAhEDEQA/AJByEcYyWPTqdB8EwfALCNGwfBMHyXYzaMlvofrn1UyX0L6wc03nIvPSr+C5wq5wHnCnnJemfe3Yk+JaJOiSay605MmzIpkzJLrPrQMkeSPJFkgLui/Lvk3y3lOg+ivLeTfLeV9J6J8ueTvLeV9L9E+WN8ui6X6eV/DIwGGxjr2PsdGxh0FQfGF2EapsG4XAt0Hlnv679b6H67g5lOjIz0q5SVylXzkGmfk0ZzlTEg5yoiWfTHvQ4k6JciTpkqsutNMmZLsyZMgsIug5IskeSLyroF0X5d8mfG+L6D2X8c+G/HPguk7K+N8M3HPi+l9lfGM+MLoXbyjDZKnDodWx9po2MOgqMOkuwjRmOfXN1z6kyX0LDuUkyq5SuwG71D+Uq+ck8pV88I0xcmjecqIkvniiMIsY90cYdOBjDpwuxl1XZwycacMzA9E2uZgswWY78Tou0Hxvhnxz4KROwfHPg9xzcX0nYHNwe45uC6F2D4wvjC6X28lk2CpOl07H2+jYNLgX0PRFF9YLuCmVHcsW8sTccWcsBqM3JVHLFXPCOeKueM+ow8lO54ojCoxRGE2Me6ZGHTgIw6cLsZtUc4ZOBnDZxXROq5mC+O5jvxOi+w/HPg/jm4KROwbgdwzcDuCkFKDcc0Wh3RTK+3GD9YXlXt5NB0EydDpWPu9Gy6FvqpkoQ4wvDuOD6Dr+KuWLOWJeWLOWE6jHyVRzxVzxPzVc2fUYeSnxiiMJ54ojCrGPZsYdGFwdILGbVMnDJwE4ZgeiNUWY78bNbdTyVdxzcDru6XWjmVfSNug3W3S9oyYV9Hd0G65ug3RzCvo79dK+sPwH6PLoOgmDpbrHo+hfXQO4uZB0PFPLE0quS7C9/wAV8sV8k3JXyI1GDkU81PNPzU8yNRi2o5qITwogq5ZNnwdKeaHlg8sfJuRRlCyk2UZNL8OfycqjNbdLym2k8s15f13dLrXKouqMmVfV3aBtObRe0ZML+gtoG0HaBtGTCfQXp0n0wvCvbzeDMKkz61eXqtE7gBYOZDTYV8kvNXyVqEcivkr5pOSvmRrLDyKuanmkij5sm5YOTUiuaMy0k2Zlh8OZzcqrLFlpcsc0nzcrl5u1c0ZNJZoeUrwxb5FWU20RlttJ4Z7szaL2g7QNocwk5BVRe0HaBtGTAvYtoG0HaBtGTC/YvTpPp0fhft59I80qdH9P8vYaPBYXmiyhTILYp5K+eoedKedK1hk5dxfzpRFIYo+LLvG5fNyrYs6bRTZk2D5uTzcq3LFlpMsc2r5uRzcyuaNmkk0bNKuHP3tVNGZaWaHlg8Mm9qctvZHtvaeCbs3aBtF7QdocwqbHtA2g7QNocwObFtA2g7QNoyYFND9MT6dH5F6fB5Qsoj07lHzD2W7PyhZSfKFlDmGffIr50p50g50oi0uGDm5F8UdNoYs6bD83I5+VdNjzojmxzavm4/PyrZs2aRzR00C4czk2rmjZpJNGTZdwyb0ryh5aXLFlh8MutKfbeyPbek8FXR205tFbYdoUwr0ZtA2gbQNocwKaM2gbRe0HaHMGTQ/TpPpheRenwm02UTtNlNWcPYtbUZQspPlCyzJhk5ORXFnxaGLOm1/NzOflXTZs9EM2bFK+bj8/KtmzopHFHRQbhy+TS2aNmkc0bNlXDFvSybMm0k2ZNguGTelWWPLS5Q8sHhn1VOW3tPlt7TwVaftubRPtzbX4Ts3aBtF7QdoUwOUzaD6K23PQ5gyUz0xXpl+Vvg6pzLKqg5bbnD1vXJ+KfTuWny3cs2YYeXkVzZs2imzooXzcvn5FsUfFI4o+KVcOXyaWRR00jijpoFww8lWTRs0jmjZoq4Y91XNmZaSbHll3DLuq8sWWmyxZYPDPqqfbe0+W77V4LP8Abm2R7c21+FnbQdorbDtCmBw3ac9E7TnoXk2HemK9MvyLp8FVA9szdmR6hrVdyxZTMbJHP5bTI1RFMyMHIfFHRTMnUYOQ6aOmmYGpGHZs0ZNMxVkZNmTQ8pmLsjLoeWLLZg9Qiiy29sweoBvbntmRcc9h2mZcMyHbb2zCOjvpmZQn/9k=',
-    text: '낭만의 액티비티, 열기구',
-    path: '/',
-    location: '인천 남동구',
-    price: 30000,
-    score: 5,
-    review: 1034,
-  },
-  {
-    url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIALcAwwMBIgACEQEDEQH/xAAZAAEBAQEBAQAAAAAAAAAAAAACAQADBAf/xAAbEAEBAQEAAwEAAAAAAAAAAAAAARECEjFBIf/EABgBAQEBAQEAAAAAAAAAAAAAAAIBAAME/8QAGREBAQEBAQEAAAAAAAAAAAAAAAERAjES/9oADAMBAAIRAxEAPwD66lVnoeMKNPoVShRp0LFg0KNOjVEBp2DViihYilEhc+0wozpysKJCjO0Vo2FGdIsZY0iKjUsaxhrnRp2DYzl0CEzOb31CsRzQKmFUUQoWOlg1hrnRrpYFiwRwbHTBsWLAqYWNhHBxcWRcZ05aFI0iyI7RYuLIuM6RpGKRcTSHPxsORsTQ6crEx0sGxHHpysZ0xGc3sTCsSwEoWJh4NUQo10wasCudGx0sGwokAa6WJilAxsLGxdODi4si4xxMKNhSJrtGkWRZFkTTiyNIUhSJpWhIuHItiWhXLBsdsG8prl05Yzp4o2ubvYxWJYkQLBx0wbFGudg2Olg2KNAbHQbFGDYFjoOLDg42EzFBKRsXGOJhRJDkSuvNaFGkKRC1ZCkaFIlpNI2HIuBqVzwbHbBvLa59OXizpiNrkTVWqtRGw76FYFc6NdKFYaI0x69GMSwaTWLDgY0KxMZWxZG+NEpxsWNC+Icq8kkKMcpQ4MOBThSHInLpIFrB4peXTGsTUs1x8WdMRtc/lzqVUdBsSpWqLHOwaNKiwClWpTRGrNVhQa0VmZmjQolKNCiQohxiglEpylDglPQk6cukDk4501+MkWIyYiszOA1dGurn01CraNqxyqVGtG1YFa1Go04NX62pakYSRtVjYoJRKsKM0VKUWHIMhARQpBhxKcpcukc4UoHKTJamti6uoHkrY2uOjatC11iVqNrWpqxxqWjVtG0nOro2talWAzJakqoRShKrNpwoPNKDTKFBhQasKFEi/BLShQYqHKTDFtQ9XRta0L02Npajn5K2No6NqWpa6SNWtG1tG0nPper+Dalo2rI5UrUtS0LSA7WlDWlVjKOcpypWOHHOHyCyukPkOTg0iKCUGrKrNUQ1qa19BWXVtC1rQ6pRtXUc7WYdW1LUtTTdbWtTUtS0sc61qWpqE5WtalS1FwNXW1GbE05Slc4UbFdYccuXXkKp8ukc4cCrK6SqMqiStKmslXWoVbR6qxdTquXVK1z6qyNqawaxYOnU1kN3raNqjVc+mGqixyqMixgZmZmYoJRmdJ6OenOOnI9LD5dI58nHNT5IYqLK1ZqlQktDqlQtVhrn3Trl1Vg2hayViTXVqjE9VT6NZmcqyMxOfQrEZgVmZmWFGZmKHGYb6sdIUZgqnCZhaJUqsxhRrMiVz69OXSsQ1yZmJH//2Q==',
-    text: '잔잔한 호수위로, 동동배',
-    path: '/',
-    location: '서울 마포구',
-    price: 50000,
-    score: 5,
-    review: 103,
-  },
-  {
-    url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIALsAyAMBIgACEQEDEQH/xAAZAAEBAQEBAQAAAAAAAAAAAAACAwEABgX/xAAZEAEBAQEBAQAAAAAAAAAAAAABABECQSH/xAAZAQEBAQEBAQAAAAAAAAAAAAACAAEDBQb/xAAWEQEBAQAAAAAAAAAAAAAAAAAAARH/2gAMAwEAAhEDEQA/APgJdkkuy9t4ugliTSxKboJYk0sSm6CXJJLkpup5Zk8uSi1NLEmkctKUMsSeWJTZU0jlRI5RygxyokUopQSKT8sS0pU0ilRIpRROxmkGigpda3Wlr0mWJNLsubx9TSxKiWJTdDLGaXJa3U0ik0uSi0Ejk8sym6mlyTSOU2UEjlRItpygkUnnyxKKVPLEmkUopQY+TyxtOUGLNIpRSpsfKjFo4Dda2U16ZLsmliQeNoJYk0sSm6CXJJLspup5Yk8sSi1PLEnkUtbKGWJUSKUaeWJPLEpsqaRyokUtOUGLPLGilTSKVEilHKmxqJFooDBqJFLSlTSybdRvTpYlRLEg8PU0uSaWJRanlyTSOU3QyxJ5YlFKnliTyxKKVNI5USKWlKCRZ5YlGnYk0ilNlTbGbFtdICRZ2NFE2LNi0UBIs2LaYN1rdRPVJYk0sSDwtFI5NLkotTSxJ5YlFqeWJNLEopU0jlRIpRSgkUnljRRNItRItpSp2M2LRgxZsUooDFmxbTgMGoxaKJsWaRadIDda3WlHrcsSaXJc3g6mkcqJHKboZYkkutbKmkcqJFKOUEik8saOVNilRilFKmkWoxaOVNiz6jacBizYtFAYs2LaUBik2LRxNizYtHAbJN1pvXpck0jlzfP6CRyqkUpsqaRyokUopQYpNjacoJFKjBo5QSLNi0UBizYtHAYs2LacBg1GDRQGLNi0cBizYNpwOos2LRwG65utN7NLEnliXJ85KmkcqJFLTlBIpPyxopU2KTYpRQGKTYtpwGDUYtHE2LNi06QGDUYNFAYs2La6QGLNg0UBizYtrpAYs2HVFAbrW6je1yxKmRS5vmpU0ilRi0cqaRZsW04DFmxaNNizYtFAYNRg2ukBizYtOkBgzYtHAYsmLaUBizYtOkBgz6i2lAYs2DRwG61uo49wxZpFub5qUEizYtFAYNRg2nAYNRh1RwGLNg0cFgzYtrpAYM2LTpAYM2LRwGLJi2nAYs2DRwWDNi0cBiyYtpQG61uo3umDUYdXJ8zAYs2DacDqLNg06QGLNg2lAYs2DTpBYM2DacFgzYNOkFgzYNHBYdTYtpwGLJi0cBizYNHBYM2DacFuubqN7th1Nh1cnzEFiyYtrpAYsmLRwGLJg2nBYM2DTpBYsmLacBgzYtHAYsuoNOkFiyYtpwWDNg0cFgyYtHBYsmLacDq2zq2jf//Z',
-    text: '빛나는 도심 속, 별 구경하기',
-    path: '/',
-    location: '서울 마포구',
-    price: 40000,
-    score: 3,
-    review: 112,
-  },
-  {
-    url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIALcAwgMBIgACEQEDEQH/xAAbAAADAQEBAQEAAAAAAAAAAAAAAQIDBAYFB//EABgQAQEBAQEAAAAAAAAAAAAAAAABEQIS/8QAGQEBAQEBAQEAAAAAAAAAAAAAAQIAAwQF/8QAGBEBAQEBAQAAAAAAAAAAAAAAAAEREgL/2gAMAwEAAhEDEQA/AP1u1NMq9CCqadKmKiamqqatUTU1dTTFRFRWlRVRURU1dLFKicGHh4xSFYMB1OHisGM2ow8VipBTKjDxfk5ym06iQYvyfkaqemeBpgbVdO1NOlUR84iplVRSSqk0mJpKqTFRNRWibFFngxeDGKMGL8jyx1GHisPBrajDkVhyC1tTOVSKkORNranyeL8icp1tRh408l5bTKzwNcA1WroAU8cKkZGLIUyJibE1pYmxlRFLFYMUU4MVgxtCcGKwYG1OHisGJGpxUhyLkFramQ8Xh4nW1Mgxch+U62owY0nI8tplZ4GnkDTrMUE7OUABsSwYYLJwrFljKicLFjGaowYvCwDU4MVh4NbUyCcqw8FTpYqQ5DkTRokOQ4qJbSkPAYOlgxUMVtRgXgB1yAB6hDhwoYIBnIFRODFeRjaySVgbRU4MUBQnAYgAwwIwqoABWioBAljhlDDHDiYqCkwAGcOmjVSvUyopEVKy4uLRzVIphkNFZqmkKTJMqCZJiEYYzhBgoCAVlQFDFY4ZHEscOEcFUAAGfPEqNOV7MZrKqVlKcosVG0qp0xnSvScLTRajRrYxlRpa2Jp6EnGBggKFQ0mkVUUmGzQ4ZGmscOEcSQcBikAAM+TKes9GvfgjaU9Y+lehio1nR+mPo50MLadK1jKeixmujWenoSvTQegLCZT0UKBGmtVRUQcAUZGKYZwocQVGk4KTAAZ8L0estGvp4I109Y+h6bC29HOmHo50MVG86V6YTpU6FgredKlYSrnSMDaU4zlVKnEVpDZyqlTWXKcqNODGWcTKcTWXKaZT1NMUcIJKjI4CYASzzXoemXoen18Q19D0x9D03Ko29idMPQnTcl0zpU6c86XOhYzonTSVzzpfPTnYzeVc6YTpcqLE1vKcrKVcqEtJVSs9VKllyqRDlFZcVEHKgrlUzVKmmLh6k0lQToYvJeh6Zei9PtY5a19D0x9D0eVStfQ9MPQnTYt1c9NOenLz0056R6jOrnpfPTn56XOnOxnROmnPTnnS+aixNdE6ac9OfnpfNRYl0SqlYzpcqLGayq1nKcqMZpKaNVKnGXKcqDThjTTlRKaKtehOhmeKtL0A+64Qr0XsAxUL0c6AZ0jTnppz0Ais056aToBzrNJ0vnoBzorSVpz0AipaTpfPQDnWXKuUBAVKegJZUqgE1cM5QEk9ACWf/9k=',
-    text: '나른한 오후 1시, 호수 구경하기',
-    path: '/',
-    location: '인천 미추홀구',
-    price: 30000,
-    score: 2,
-    review: 103,
-  },
-];
-
 const Main = () => {
   const navigate = useNavigate();
-  const [filteredData, setFilteredData] = useState(datas);
+  const { productAll, optionAll } = useProductAll();
+  const { data: reviewAll } = useReviewAllQuery();
+  const combinedData = useProductOptionsReviews(
+    productAll,
+    optionAll,
+    reviewAll,
+  );
+  const { sortedCategoryAccommodation, sortedCategoryActivity } =
+    useFilterByCategory(combinedData);
 
-  // 화면 크기에 따라 데이터를 필터링
-  const handleResize = () => {
-    if (window.innerWidth >= 1199) {
-      setFilteredData(datas.slice(0, 4)); // PC일 때는 4개의 데이터
-    } else {
-      setFilteredData(datas.slice(0, 3)); // 태블릿일 때는 3개의 데이터
-    }
+  const transformData = (data: any, categoryId: number) => {
+    return (
+      data &&
+      data.map((item: any) => ({
+        url: item.thumbnail,
+        text: item.name,
+        path: `detail/${categoryId}/${item.id}`,
+        location: item.productAddress,
+        price: item.minPrice,
+        score: item.averageScore,
+        review: item.reviewCount,
+      }))
+    );
   };
+
+  const [displayCount, setDisplayCount] = useState(4);
 
   useEffect(() => {
-    handleResize();
-    window.addEventListener('resize', handleResize); // 화면 크기 변경 시 실행
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
+    const updateDisplayCount = () => {
+      if (window.innerWidth >= 1199) {
+        setDisplayCount(4);
+      } else if (window.innerWidth >= 768) {
+        setDisplayCount(3);
+      } else {
+        setDisplayCount(4);
+      }
     };
+
+    window.addEventListener('resize', updateDisplayCount);
+    updateDisplayCount();
+
+    return () => window.removeEventListener('resize', updateDisplayCount);
   }, []);
 
-  // TODO: 경로 맞게 수정하기 (지금은 임시 ..)
+  const transformedAccommodation = transformData(
+    sortedCategoryAccommodation,
+    3,
+  );
+  const transformedActivity = transformData(sortedCategoryActivity, 20);
+
+  const CategoryAccommodation = transformedAccommodation
+    ? transformedAccommodation.slice(0, displayCount)
+    : [];
+  const CategoryActivity = transformedActivity
+    ? transformedActivity.slice(0, displayCount)
+    : [];
+
   const handleAccommodation = () => {
-    navigate('./list');
+    navigate('/list/3');
   };
   const handleActivity = () => {
-    navigate('./list');
+    navigate('/list/20');
   };
 
   return (
@@ -117,14 +117,14 @@ const Main = () => {
         <Carousel items={carousel} />
         <div className="flex justify-center p-20 pb-5 mb-80">
           <MainCard
-            images={filteredData}
+            images={CategoryAccommodation}
             title="인기많은 숙소"
             onclick={handleAccommodation}
           />
         </div>
         <div className="flex justify-center p-20 pb-5">
           <MainCard
-            images={filteredData}
+            images={CategoryActivity}
             title="인기많은 액티비티"
             onclick={handleActivity}
           />

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -16,7 +16,7 @@ interface ProductCardProps {
   id: number;
   name: string;
   productAddress: string;
-  productImages: string;
+  thumbnail: string;
   minPrice: number;
 }
 
@@ -24,7 +24,7 @@ const ProductCard = ({
   id,
   name,
   productAddress,
-  productImages,
+  thumbnail,
   minPrice,
 }: ProductCardProps) => {
   const { avg, length } = useScoreAvg(id);
@@ -37,7 +37,7 @@ const ProductCard = ({
       price={minPrice}
       score={avg}
       review={length}
-      image={productImages}
+      image={thumbnail}
       link="/"
     />
   );
@@ -126,7 +126,7 @@ const SearchResultPage = () => {
               id={item.id}
               name={item.name}
               productAddress={item.productAddress}
-              productImages={item.productImages}
+              thumbnail={item.thumbnail}
               minPrice={item.minPrice}
             />
           ))}


### PR DESCRIPTION
## 🚀 작업 내용

- 데이터 숙소, 체험 등록하기
- 더보기 버튼 수정
- 캐러셀 텍스트 및 백그라운드 제거 
- api 가져오기 성공 (모든 상품, 모든 옵션, 모든 리뷰) 
- 메인 페이지에 필요한 데이터들 합친 커스텀 훅 구현
- 카드 렌더링 될때 썸네일로 사진이 등록되게 구현 

## 📝 참고 사항

-

## 🖼️ 스크린샷
![스크린샷 2024-06-07 오후 4 09 05](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/114905530/bd4ee6a0-f358-4d1f-b398-38e0af5b9f5e)


## 🚨 관련 이슈

- close-#(issue_number)