### PR TITLE
[Refactor] 일반 유저 로그인, 파트너 로그인 시 다른 화면 렌더링

### DIFF
--- a/src/components/common/headerBar/LoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/LoginUserHeaderBar.tsx
@@ -180,11 +180,13 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
             className="rounded-full cursor-pointer h-[3.2rem] w-[3.2rem]"
           />
         </button>
-        <img
-          className="h-[3.2rem] w-[3.2rem]"
-          src={cart}
-          alt="쇼핑 카트 아이콘"
-        />
+        {userInfo.isPartner === 0 && (
+          <img
+            className="h-[3.2rem] w-[3.2rem]"
+            src={cart}
+            alt="쇼핑 카트 아이콘"
+          />
+        )}
       </div>
       <div className="hidden mobile:flex">
         <button type="button" onClick={toggleSidebar}>
@@ -198,10 +200,10 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
       {isDropdownOpen && (
         <div
           ref={dropdownRef}
-          className="absolute mt-10 bg-white border border-gray-300 shadow-[0px_0px_10px_0px_rgba(0,0,0,0.25)] top-full rounded-[1.2rem] pt-[0.8rem] pb-[0.4rem]"
+          className="left-[-2rem] absolute mt-10 bg-white border border-gray-300 shadow-[0px_0px_10px_0px_rgba(0,0,0,0.25)] top-full rounded-[1.2rem] pt-[0.8rem] pb-[0.4rem]"
           style={{ marginLeft: '-1.5rem', width: 'auto' }}
         >
-          <ul className="w-[106px] text-[1.5rem] font-normal">
+          <ul className="w-[106px] text-[1.5rem] font-normal ">
             {/* 프로필 이미지랑 이름 */}
             <li className="items-center hidden p-2 mobile:flex px-[1.2rem] justify-between py-1.5 hover:bg-blue-50">
               <div className="flex items-center gap-[0.8rem]">

--- a/src/components/common/headerBar/LoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/LoginUserHeaderBar.tsx
@@ -42,7 +42,7 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const navagate = useNavigate();
   const { mutate: logout } = useLogoutMutation();
-  const { userInfo } = useUserStore();
+  const { userInfo, setUserInfo } = useUserStore();
 
   const defaultImages = [
     defaul1Img1,
@@ -79,6 +79,13 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
   });
 
   const clickLogoutButton = () => {
+    setUserInfo({
+      id: 0,
+      name: '',
+      email: '',
+      profileImage: '',
+      isPartner: 0,
+    });
     setIsLoggedIn(false);
     removeCookie('accessToken');
     removeCookie('refreshToken');

--- a/src/components/common/headerBar/UnLoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/UnLoginUserHeaderBar.tsx
@@ -64,7 +64,7 @@ const UnLoginUserHeaderBar = () => {
               outlined
               buttonStyle="text-14 p-8 font-semibold"
               onClick={() => {
-                navigate('/partner');
+                navigate('/signup/partner');
                 setIsMenuOpen(false);
               }}
             >

--- a/src/components/common/headerBar/UnLoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/UnLoginUserHeaderBar.tsx
@@ -64,7 +64,7 @@ const UnLoginUserHeaderBar = () => {
               outlined
               buttonStyle="text-14 p-8 font-semibold"
               onClick={() => {
-                navigate('./partner');
+                navigate('/partner');
                 setIsMenuOpen(false);
               }}
             >
@@ -73,7 +73,7 @@ const UnLoginUserHeaderBar = () => {
             <Button
               buttonStyle="text-14 p-8 font-semibold"
               onClick={() => {
-                navigate('./login');
+                navigate('/login');
                 setIsMenuOpen(false);
               }}
             >
@@ -89,7 +89,7 @@ const UnLoginUserHeaderBar = () => {
           outlined
           buttonStyle="min-w-fit text-14 p-10 font-semibold"
           onClick={() => {
-            navigate('./partner');
+            navigate('/partner');
           }}
         >
           파트너 페이지
@@ -97,7 +97,7 @@ const UnLoginUserHeaderBar = () => {
         <Button
           buttonStyle="min-w-fit text-14 p-10 font-semibold"
           onClick={() => {
-            navigate('./login');
+            navigate('/login');
           }}
         >
           로그인 및 회원가입

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -4,16 +4,16 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable react/no-array-index-key */
 import { useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
 import useProductAll from '@/hooks/reactQuery/product/useProductAll';
-import useReviewAllQuery from '@/hooks/reactQuery/review/useReviewAllQuery';
-import useProductOptionsReviews from '@/hooks/useProductOptionsReviews';
 import useFilterByCategory from '@/hooks/useFilterByCategory';
 import useDisplayCount from '@/hooks/useDispalyControl';
+import { useUserStore } from '@/utils/zustand';
+import { getCookie } from '@/utils/cookie';
 import Carousel from '@/components/Carousel';
 import Footer from '@/components/common/Footer';
 import Layout from '@/components/common/layout/Layout';
 import MainCard from '@/components/MainCard';
+import PartnerMain from './PartnerMain';
 
 interface ImageItem {
   url: string;
@@ -49,6 +49,7 @@ const carousel: ImageItem[] = [
 const Main = () => {
   const navigate = useNavigate();
   const { productAll } = useProductAll();
+  const { userInfo } = useUserStore();
 
   // 카테고리로 분류
   const { sortedCategoryAccommodation, sortedCategoryActivity } =
@@ -91,6 +92,11 @@ const Main = () => {
     navigate('/list/2');
   };
 
+  if (userInfo) {
+    if (userInfo.isPartner === 1) {
+      return <PartnerMain />;
+    }
+  }
   return (
     <>
       <Layout main category noSearch={false}>


### PR DESCRIPTION
## 🚀 작업 내용

- 일반 유저 로그인, 파트너 로그인 시 메인페이지 다르게 보여주기
- 로그아웃 시 userInfo 초기화
- 헤더 파트너 페이지 클릭 시 파트너 회원가입 화면으로 이동 
- 파트너 로그인 시 장바구니 헤더에 안 보이게 구현
- 드롭다운 위치 프로필 이미지 가운데 아래로 조정 

## 📝 참고 사항

- 로그인 안 했을때 파트너 페이지 클릭 시 파트너 회원가입 쪽으로 이동하게 했는데, 맞을까요? 아니라면 어디로 이동해야 하는지도 알려주세요 😭

## 🖼️ 스크린샷
![스크린샷 2024-06-13 오후 2 05 11](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/114905530/21f0e44f-978a-46d5-ae66-052c7e5c7611)
![스크린샷 2024-06-13 오후 2 05 39](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/114905530/b90a0f0a-5558-46a4-b039-4dd52e0015b3)

## 🚨 관련 이슈

- close-#(issue_number)
