### PR TITLE
[API] Auth(로그인, 회원가입) React Query 적용 완료, 기타 버그 수정

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -6,6 +6,13 @@ type LoginForm = {
   password: string;
 };
 
+type SignupForm = {
+  name: string;
+  email: string;
+  password: string;
+  loginType: 'USER' | 'PARTNER';
+};
+
 type UserSignupForm = {
   nickname: string;
   email: string;
@@ -78,6 +85,20 @@ export const postVerifyEmail = async (email: string): Promise<any> => {
     method: 'POST',
     data: {
       email,
+    },
+  });
+};
+
+export const postSignup = async (data: SignupForm): Promise<any> => {
+  const { name, email, password, loginType } = data;
+  return instance({
+    url: '/auth/signup',
+    method: 'POST',
+    data: {
+      name,
+      email,
+      password,
+      loginType,
     },
   });
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,5 +1,4 @@
 import instance from '@/utils/axios';
-import axios from 'axios';
 
 type LoginForm = {
   email: string;
@@ -11,18 +10,6 @@ type SignupForm = {
   email: string;
   password: string;
   loginType: 'USER' | 'PARTNER';
-};
-
-type UserSignupForm = {
-  nickname: string;
-  email: string;
-  password: string;
-};
-
-type PartnerSignupForm = {
-  company: string;
-  email: string;
-  password: string;
 };
 
 /**
@@ -76,7 +63,7 @@ export const getNaverLogin = async (code: string | null): Promise<any> => {
 };
 
 /**
- * 회원가입(유저(user), 파트너(partner))
+ * 회원가입(이메일 중복 확인, 회원가입 API)
  */
 
 export const postVerifyEmail = async (email: string): Promise<any> => {
@@ -101,46 +88,4 @@ export const postSignup = async (data: SignupForm): Promise<any> => {
       loginType,
     },
   });
-};
-
-export const postUserSignup = async (data: UserSignupForm) => {
-  const { nickname: name, email, password } = data;
-  const loginType = 'USER';
-  try {
-    const res = await instance.post('auth/signup', {
-      name,
-      email,
-      password,
-      loginType,
-    });
-    const result = res.data;
-    return result;
-  } catch (error: any) {
-    if (axios.isAxiosError(error) && error.response?.status === 400) {
-      throw new Error(error.response.data.message);
-    } else {
-      throw new Error(error.message);
-    }
-  }
-};
-
-export const postPartnerSignup = async (data: PartnerSignupForm) => {
-  const { company: name, email, password } = data;
-  const loginType = 'PARTNER';
-  try {
-    const res = await instance.post('auth/signup', {
-      name,
-      email,
-      password,
-      loginType,
-    });
-    const result = res.data;
-    return result;
-  } catch (error: any) {
-    if (axios.isAxiosError(error) && error.response?.status === 400) {
-      throw new Error(error.response.data.message);
-    } else {
-      throw new Error(error.message);
-    }
-  }
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -71,18 +71,15 @@ export const getNaverLogin = async (code: string | null): Promise<any> => {
 /**
  * 회원가입(유저(user), 파트너(partner))
  */
-export const postVerifyEmail = async (email: string) => {
-  try {
-    const res = await instance.post('auth/valid-email', { email });
-    const result = res.data;
-    return result;
-  } catch (error: any) {
-    if (axios.isAxiosError(error) && error.response?.status === 400) {
-      throw new Error(error.response.data.message);
-    } else {
-      throw new Error(error.message);
-    }
-  }
+
+export const postVerifyEmail = async (email: string): Promise<any> => {
+  return instance({
+    url: '/auth/valid-email',
+    method: 'POST',
+    data: {
+      email,
+    },
+  });
 };
 
 export const postUserSignup = async (data: UserSignupForm) => {

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,5 +1,4 @@
 import instance from '@/utils/axios';
-import { setCookie } from '@/utils/cookie';
 import axios from 'axios';
 
 type LoginForm = {
@@ -23,7 +22,10 @@ type PartnerSignupForm = {
  * 로그아웃
  */
 export const postLogout = () => {
-  return instance.post('auth/logout');
+  return instance({
+    url: '/auth/logout',
+    method: 'POST',
+  });
 };
 
 /**
@@ -45,40 +47,25 @@ export const postLogin = async (data: LoginForm): Promise<any> => {
   });
 };
 
-export const getGoogleLogin = async (code: string | null) => {
-  try {
-    const res = await instance.get(`auth/google/callback?code=${code}`);
-    const ACCESS_TOKEN = res.data.accessToken;
-    setCookie('accessToken', ACCESS_TOKEN);
-  } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 500) {
-      throw new Error(error.response.data.message);
-    }
-  }
+export const getGoogleLogin = async (code: string | null): Promise<any> => {
+  return instance({
+    url: `/auth/google/callback?code=${code}`,
+    method: 'GET',
+  });
 };
 
-export const getKakaoLogin = async (code: string | null) => {
-  try {
-    const res = await instance.get(`auth/kakao/callback?code=${code}`);
-    const ACCESS_TOKEN = res.data.accessToken;
-    setCookie('accessToken', ACCESS_TOKEN);
-  } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 500) {
-      throw new Error(error.response.data.message);
-    }
-  }
+export const getKakaoLogin = async (code: string | null): Promise<any> => {
+  return instance({
+    url: `/auth/kakao/callback?code=${code}`,
+    method: 'GET',
+  });
 };
 
-export const getNaverLogin = async (code: string | null) => {
-  try {
-    const res = await instance.get(`auth/naver/callback?code=${code}`);
-    const ACCESS_TOKEN = res.data.accessToken;
-    setCookie('accessToken', ACCESS_TOKEN);
-  } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 500) {
-      throw new Error(error.response.data.message);
-    }
-  }
+export const getNaverLogin = async (code: string | null): Promise<any> => {
+  return instance({
+    url: `/auth/naver/callback?code=${code}`,
+    method: 'GET',
+  });
 };
 
 /**

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -33,25 +33,16 @@ export const postLogout = () => {
 /**
  * 로그인 & 소셜 로그인(Google, Kakao, Naver), Access Token Cookie 저장
  */
-export const postLogin = async (data: LoginForm) => {
+export const postLogin = async (data: LoginForm): Promise<any> => {
   const { email, password } = data;
-  try {
-    const res = await instance.post('auth/login', {
+  return instance({
+    url: '/auth/login',
+    method: 'POST',
+    data: {
       email,
       password,
-    });
-    const result = res.data;
-    const ACCESS_TOKEN = result.accessToken;
-    setCookie('accessToken', ACCESS_TOKEN);
-  } catch (error: any) {
-    if (axios.isAxiosError(error) && error.response?.status === 401) {
-      throw new Error(error.response.data.message);
-    } else if (axios.isAxiosError(error) && error.response?.status === 500) {
-      throw new Error(error.response.data.message);
-    } else {
-      throw new Error(error.message);
-    }
-  }
+    },
+  });
 };
 
 export const getGoogleLogin = async (code: string | null) => {

--- a/src/components/common/reservPagination/ResevationCard.tsx
+++ b/src/components/common/reservPagination/ResevationCard.tsx
@@ -35,7 +35,7 @@ const ReservationCard = ({
 
   return (
     <div
-      id={id.toString()}
+      id={id ? id.toString() : 'undefined'}
       className="flex flex-col p-16 w-full max-w-834 gap-32 border-1 border-black-5 rounded-8"
     >
       <div className="flex flex-col justify-between gap-32">

--- a/src/hooks/reactQuery/auth/useLoginMutation.ts
+++ b/src/hooks/reactQuery/auth/useLoginMutation.ts
@@ -1,7 +1,10 @@
 import { postLogin } from '@/apis/auth';
-import { setCookie } from '@/utils/cookie';
+import { getCookie, setCookie } from '@/utils/cookie';
+import jwtDecode from '@/utils/jwtDecode';
+import { useUserStore } from '@/utils/zustand';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 type LoginForm = {
   email: string;
@@ -9,12 +12,22 @@ type LoginForm = {
 };
 
 const useLoginMutation = () => {
+  const setUserInfo = useUserStore((state) => state.setUserInfo);
+  const navigate = useNavigate();
   return useMutation({
     mutationFn: async (data: LoginForm) => {
       const res = await postLogin(data);
       const ACCESS_TOKEN = res.data.accessToken;
       setCookie('accessToken', ACCESS_TOKEN);
       return res.data;
+    },
+    onSuccess: () => {
+      const token = getCookie('accessToken');
+      if (token) {
+        const userInfo = jwtDecode(token);
+        setUserInfo(userInfo);
+        navigate('/');
+      }
     },
     onError(error) {
       if (axios.isAxiosError(error) && error.response?.status === 401) {

--- a/src/hooks/reactQuery/auth/useLoginMutation.ts
+++ b/src/hooks/reactQuery/auth/useLoginMutation.ts
@@ -1,0 +1,31 @@
+import { postLogin } from '@/apis/auth';
+import { setCookie } from '@/utils/cookie';
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+
+type LoginForm = {
+  email: string;
+  password: string;
+};
+
+const useLoginMutation = () => {
+  return useMutation({
+    mutationFn: async (data: LoginForm) => {
+      const res = await postLogin(data);
+      const ACCESS_TOKEN = res.data.accessToken;
+      setCookie('accessToken', ACCESS_TOKEN);
+      return res.data;
+    },
+    onError(error) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        throw new Error(error.response.data.message);
+      } else if (axios.isAxiosError(error) && error.response?.status === 500) {
+        throw new Error(error.response.data.message);
+      } else {
+        throw new Error(error.message);
+      }
+    },
+  });
+};
+
+export default useLoginMutation;

--- a/src/hooks/reactQuery/auth/useSignupMutation.ts
+++ b/src/hooks/reactQuery/auth/useSignupMutation.ts
@@ -1,0 +1,20 @@
+import { postSignup } from '@/apis/auth';
+import { useMutation } from '@tanstack/react-query';
+
+type SignupForm = {
+  name: string;
+  email: string;
+  password: string;
+  loginType: 'USER' | 'PARTNER';
+};
+
+const useSignupMutation = () => {
+  return useMutation({
+    mutationFn: async (data: SignupForm) => {
+      const res = await postSignup(data);
+      return res.data;
+    },
+  });
+};
+
+export default useSignupMutation;

--- a/src/hooks/reactQuery/auth/useSocialLoginMutation.ts
+++ b/src/hooks/reactQuery/auth/useSocialLoginMutation.ts
@@ -1,0 +1,53 @@
+import { getGoogleLogin, getKakaoLogin, getNaverLogin } from '@/apis/auth';
+import { getCookie, setCookie } from '@/utils/cookie';
+import jwtDecode from '@/utils/jwtDecode';
+import { useUserStore } from '@/utils/zustand';
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+type Provider = 'google' | 'kakao' | 'naver';
+
+const useSocialLoginMutation = (loginType: Provider) => {
+  const navigate = useNavigate();
+  const setUserInfo = useUserStore((state) => state.setUserInfo);
+
+  const getLoginAPI = (code: string | null) => {
+    switch (loginType) {
+      case 'google':
+        return getGoogleLogin(code);
+      case 'kakao':
+        return getKakaoLogin(code);
+      case 'naver':
+        return getNaverLogin(code);
+      default:
+        throw new Error('Unsupported login type');
+    }
+  };
+
+  return useMutation({
+    mutationFn: async (code: string | null) => {
+      const res = await getLoginAPI(code);
+      const ACCESS_TOKEN = res.data.accessToken;
+      setCookie('accessToken', ACCESS_TOKEN);
+      return res;
+    },
+    onSuccess: () => {
+      const token = getCookie('accessToken');
+      if (token) {
+        const userInfo = jwtDecode(token);
+        setUserInfo(userInfo);
+        navigate('/');
+      }
+    },
+    onError: (error) => {
+      if (axios.isAxiosError(error) && error.response?.status === 500) {
+        throw new Error(error.response.data.message);
+      }
+    },
+  });
+};
+
+export const useGoogleLoginMutation = () => useSocialLoginMutation('google');
+export const useKakaoLoginMutation = () => useSocialLoginMutation('kakao');
+export const useNaverLoginMutation = () => useSocialLoginMutation('naver');

--- a/src/hooks/reactQuery/auth/useVerifyEmail.ts
+++ b/src/hooks/reactQuery/auth/useVerifyEmail.ts
@@ -1,0 +1,13 @@
+import { postVerifyEmail } from '@/apis/auth';
+import { useMutation } from '@tanstack/react-query';
+
+const useVerifyEmail = () => {
+  return useMutation({
+    mutationFn: async (email: string) => {
+      const res = await postVerifyEmail(email);
+      return res.data;
+    },
+  });
+};
+
+export default useVerifyEmail;

--- a/src/hooks/useOAuthLogin.ts
+++ b/src/hooks/useOAuthLogin.ts
@@ -22,4 +22,6 @@ const useOAuthLogin = (provider: Provider) => {
   return loginHandler;
 };
 
-export default useOAuthLogin;
+export const useGoogleLogin = () => useOAuthLogin('google');
+export const useKakaoLogin = () => useOAuthLogin('kakao');
+export const useNaverLogin = () => useOAuthLogin('naver');

--- a/src/pages/ReservationManagement.tsx
+++ b/src/pages/ReservationManagement.tsx
@@ -34,7 +34,7 @@ const ReservationManagement = () => {
 
       return result;
     } catch (e: any) {
-      return e.message;
+      return '';
     }
   };
 
@@ -77,7 +77,7 @@ const ReservationManagement = () => {
   const end = start + limit;
 
   return (
-    <div className="mx-10 my-0">
+    <div className="mx-10 my-0 w-1000">
       <div className="flex flex-col gap-60 mt-60">
         <div className="flex flex-col gap-20">
           <div className="font-bold text-24">예약 관리</div>

--- a/src/pages/auth/login/GoogleRedirect.tsx
+++ b/src/pages/auth/login/GoogleRedirect.tsx
@@ -1,19 +1,15 @@
-import { getGoogleLogin } from '@/apis/auth';
+import { useGoogleLoginMutation } from '@/hooks/reactQuery/auth/useSocialLoginMutation';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 const GoogleRedirect = () => {
   const code = new URL(window.location.href).searchParams.get('code');
-  const navigate = useNavigate();
+  const { mutate } = useGoogleLoginMutation();
 
   useEffect(() => {
-    try {
-      getGoogleLogin(code);
-      navigate('/', { replace: true });
-    } catch (error: any) {
-      alert(error.message);
+    if (code) {
+      mutate(code);
     }
-  }, [code]);
+  }, [code, mutate]);
 
   return (
     <div>

--- a/src/pages/auth/login/KakaoRedirect.tsx
+++ b/src/pages/auth/login/KakaoRedirect.tsx
@@ -1,19 +1,15 @@
-import { getKakaoLogin } from '@/apis/auth';
+import { useKakaoLoginMutation } from '@/hooks/reactQuery/auth/useSocialLoginMutation';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 const KakaoRedirect = () => {
   const code = new URL(window.location.href).searchParams.get('code');
-  const navigate = useNavigate();
+  const { mutate } = useKakaoLoginMutation();
 
   useEffect(() => {
-    try {
-      getKakaoLogin(code);
-      navigate('/', { replace: true });
-    } catch (error: any) {
-      alert(error.message);
+    if (code) {
+      mutate(code);
     }
-  }, [code]);
+  }, [code, mutate]);
 
   return (
     <div>

--- a/src/pages/auth/login/Login.tsx
+++ b/src/pages/auth/login/Login.tsx
@@ -2,7 +2,11 @@ import Google from '@/assets/images/google_login.png';
 import Kakao from '@/assets/images/kakao_login.svg';
 import Naver from '@/assets/images/naver_login.png';
 import { Link, useNavigate } from 'react-router-dom';
-import useOAuthLogin from '@/hooks/useOAuthLogin';
+import {
+  useGoogleLogin,
+  useKakaoLogin,
+  useNaverLogin,
+} from '@/hooks/useOAuthLogin';
 import { useForm } from 'react-hook-form';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
@@ -24,9 +28,9 @@ const Login = () => {
     handleSubmit,
     formState: { errors },
   } = useForm<LoginForm>({ mode: 'onChange' });
-  const googleLogin = useOAuthLogin('google');
-  const kakaoLogin = useOAuthLogin('kakao');
-  const naverLogin = useOAuthLogin('naver');
+  const googleLogin = useGoogleLogin();
+  const kakaoLogin = useKakaoLogin();
+  const naverLogin = useNaverLogin();
   const navigate = useNavigate();
   const setUserInfo = useUserStore((state) => state.setUserInfo);
   const { mutate } = useLoginMutation();

--- a/src/pages/auth/login/Login.tsx
+++ b/src/pages/auth/login/Login.tsx
@@ -6,10 +6,10 @@ import useOAuthLogin from '@/hooks/useOAuthLogin';
 import { useForm } from 'react-hook-form';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
-import { postLogin } from '@/apis/auth';
 import { getCookie } from '@/utils/cookie';
 import jwtDecode from '@/utils/jwtDecode';
 import { useUserStore } from '@/utils/zustand';
+import useLoginMutation from '@/hooks/reactQuery/auth/useLoginMutation';
 import InputBox from '@/components/common/InputBox';
 import Button from '@/components/common/Button';
 
@@ -29,16 +29,19 @@ const Login = () => {
   const naverLogin = useOAuthLogin('naver');
   const navigate = useNavigate();
   const setUserInfo = useUserStore((state) => state.setUserInfo);
+  const { mutate } = useLoginMutation();
 
-  const handleLoginForm = async (data: LoginForm) => {
-    try {
-      await postLogin(data);
-      const accessToken = getCookie('accessToken');
-      if (accessToken) setUserInfo({ ...jwtDecode(accessToken) });
-      navigate('/', { replace: true });
-    } catch (error: any) {
-      alert(error.message);
-    }
+  const handleLoginForm = (data: LoginForm) => {
+    mutate(data, {
+      onSuccess: () => {
+        const token = getCookie('accessToken');
+        if (token) {
+          const userInfo = jwtDecode(token);
+          setUserInfo(userInfo);
+          navigate('/');
+        }
+      },
+    });
   };
 
   return (

--- a/src/pages/auth/login/Login.tsx
+++ b/src/pages/auth/login/Login.tsx
@@ -1,7 +1,7 @@
 import Google from '@/assets/images/google_login.png';
 import Kakao from '@/assets/images/kakao_login.svg';
 import Naver from '@/assets/images/naver_login.png';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   useGoogleLogin,
   useKakaoLogin,
@@ -10,9 +10,7 @@ import {
 import { useForm } from 'react-hook-form';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
-import { getCookie } from '@/utils/cookie';
-import jwtDecode from '@/utils/jwtDecode';
-import { useUserStore } from '@/utils/zustand';
+
 import useLoginMutation from '@/hooks/reactQuery/auth/useLoginMutation';
 import InputBox from '@/components/common/InputBox';
 import Button from '@/components/common/Button';
@@ -31,21 +29,10 @@ const Login = () => {
   const googleLogin = useGoogleLogin();
   const kakaoLogin = useKakaoLogin();
   const naverLogin = useNaverLogin();
-  const navigate = useNavigate();
-  const setUserInfo = useUserStore((state) => state.setUserInfo);
   const { mutate } = useLoginMutation();
 
   const handleLoginForm = (data: LoginForm) => {
-    mutate(data, {
-      onSuccess: () => {
-        const token = getCookie('accessToken');
-        if (token) {
-          const userInfo = jwtDecode(token);
-          setUserInfo(userInfo);
-          navigate('/');
-        }
-      },
-    });
+    mutate(data);
   };
 
   return (

--- a/src/pages/auth/login/NaverRedirect.tsx
+++ b/src/pages/auth/login/NaverRedirect.tsx
@@ -1,19 +1,15 @@
-import { getNaverLogin } from '@/apis/auth';
+import { useNaverLoginMutation } from '@/hooks/reactQuery/auth/useSocialLoginMutation';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 const NaverRedirect = () => {
   const code = new URL(window.location.href).searchParams.get('code');
-  const navigate = useNavigate();
+  const { mutate } = useNaverLoginMutation();
 
   useEffect(() => {
-    try {
-      getNaverLogin(code);
-      navigate('/', { replace: true });
-    } catch (error: any) {
-      alert(error.message);
+    if (code) {
+      mutate(code);
     }
-  }, [code]);
+  }, [code, mutate]);
 
   return (
     <div>

--- a/src/pages/auth/signup/PartnerSignup.tsx
+++ b/src/pages/auth/signup/PartnerSignup.tsx
@@ -3,10 +3,11 @@ import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
-import { postPartnerSignup, postVerifyEmail } from '@/apis/auth';
+import { postPartnerSignup } from '@/apis/auth';
 import { useUserStore } from '@/utils/zustand';
 import { getCookie } from '@/utils/cookie';
 import jwtDecode from '@/utils/jwtDecode';
+import useVerifyEmail from '@/hooks/reactQuery/auth/useVerifyEmail';
 import Button from '@/components/common/Button';
 import InputBox from '@/components/common/InputBox';
 
@@ -35,6 +36,7 @@ const PartnerSignup = () => {
   const [isEmailValid, setIsEmailValid] = useState(false);
   const [emailMessage, setEmailMessage] = useState('');
   const setUserInfo = useUserStore((state) => state.setUserInfo);
+  const { mutate } = useVerifyEmail();
 
   const checkBtnBasic = 'absolute px-8 py-4 text-13 rounded top-44 right-12';
 
@@ -51,14 +53,20 @@ const PartnerSignup = () => {
 
   const handleCheckEmail = async () => {
     const email = watch('email');
-    try {
-      const data = await postVerifyEmail(email);
-      setIsEmailValid(data.result);
-      setEmailMessage(data.message);
-    } catch (e: any) {
-      setIsEmailValid(false);
-      setEmailMessage(e.message);
-    }
+    mutate(email, {
+      onSuccess: (data) => {
+        setIsEmailValid(data.result);
+        setEmailMessage(data.message);
+      },
+      onError: (error: any) => {
+        setIsEmailValid(false);
+        if (error.response?.status === 400) {
+          setEmailMessage('이미 가입된 회원입니다.');
+        } else {
+          setEmailMessage(error.message);
+        }
+      },
+    });
   };
 
   const handleSignupForm = async (data: PartnerSignupData) => {

--- a/src/pages/auth/signup/PartnerSignup.tsx
+++ b/src/pages/auth/signup/PartnerSignup.tsx
@@ -95,7 +95,7 @@ const PartnerSignup = () => {
                 required: '이름 또는 법인명을 입력해주세요.',
               })}
             />
-            <div className="flex gap-10">
+            <div className="flex flex-col gap-10">
               <div className="relative">
                 <InputBox
                   id="email"

--- a/src/pages/auth/signup/UserSignup.tsx
+++ b/src/pages/auth/signup/UserSignup.tsx
@@ -3,11 +3,11 @@ import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/InputType';
 import Logo from '@/assets/icons/travelPortLogo.svg';
-import { postUserSignup } from '@/apis/auth';
 import { getCookie } from '@/utils/cookie';
 import jwtDecode from '@/utils/jwtDecode';
 import useVerifyEmail from '@/hooks/reactQuery/auth/useVerifyEmail';
 import { useUserStore } from '@/utils/zustand';
+import useSignupMutation from '@/hooks/reactQuery/auth/useSignupMutation';
 import Button from '@/components/common/Button';
 import InputBox from '@/components/common/InputBox';
 
@@ -20,6 +20,8 @@ interface UserSignupData {
 interface UserSignupForm extends UserSignupData {
   passwordCheck: string;
 }
+
+type UserType = 'USER' | 'PARTNER';
 
 const UserSignup = () => {
   const {
@@ -36,7 +38,8 @@ const UserSignup = () => {
   const [isEmailValid, setIsEmailValid] = useState(false);
   const [emailMessage, setEmailMessage] = useState('');
   const setUserInfo = useUserStore((state) => state.setUserInfo);
-  const { mutate } = useVerifyEmail();
+  const { mutate: verifyEmail } = useVerifyEmail();
+  const { mutate: signUp } = useSignupMutation();
 
   const checkBtnBasic = 'absolute px-8 py-4 text-13 rounded top-44 right-12';
 
@@ -53,7 +56,7 @@ const UserSignup = () => {
 
   const handleCheckEmail = async () => {
     const email = watch('email');
-    mutate(email, {
+    verifyEmail(email, {
       onSuccess: (data) => {
         setIsEmailValid(data.result);
         setEmailMessage(data.message);
@@ -70,16 +73,21 @@ const UserSignup = () => {
   };
 
   const handleSignupForm = async (data: UserSignupData) => {
-    try {
-      await postUserSignup(data);
-      if (isEmailValid) {
-        const accessToken = getCookie('accessToken');
-        if (accessToken) setUserInfo({ ...jwtDecode(accessToken) });
-        navigate('/login', { replace: true });
-      }
-    } catch (e: any) {
-      alert(e.message);
-    }
+    const { nickname: name, email, password } = data;
+    const loginType: UserType = 'USER';
+    const signupData = { name, email, password, loginType };
+    signUp(signupData, {
+      onSuccess: () => {
+        if (isEmailValid) {
+          const accessToken = getCookie('accessToken');
+          if (accessToken) setUserInfo({ ...jwtDecode(accessToken) });
+          navigate('/login', { replace: true });
+        }
+      },
+      onError: (error: any) => {
+        alert(error.message);
+      },
+    });
   };
 
   return (


### PR DESCRIPTION
## 🚀 작업 내용

- 로그인(이메일, 소셜 로그인), 회원가입(일반 유저, 파트너) 관련 React-Query 적용
    - 기존 try-catch문에서 custom hook을 생성하여 react query 방식 적용
- 회원가입 API(postSignup) 통합
    - 기존 : 일반 유저(USER), 파트너(PARTNER)별 별도의 Signup Method 구성
    - 변경 : 하나의 postSignup 구성, data를 받아올 때 loginType까지 설정하도록 설정
- 파트너 회원가입 페이지에서 중복 체크 시, 안내 메세지가 비정상적으로 출력되던 문제 해결

## 📝 참고 사항

- 정상적으로 회원가입을 하더라도 400 에러가 나오는 문제가 있습니다. 해당 에러는 백엔드의 에러로 보이나, 계정 자체는 정상 생성됩니다.
- 지인님이 지적해주신대로 api를 다시 확인하던 중 흐름상 자연스럽지 않은 부분이 존재하여 수정이 필요해보입니다.

## 🖼️ 스크린샷

## 🚨 관련 이슈

- close-#(issue_number)
