### PR TITLE
[Feat, API] 파트너 게시물 관리 페이지 링크 연결, 구현 및 관련 API, hook 추가, 파트너 메인 페이지 내 버튼 클릭 시 링크 이동 추가

### DIFF
--- a/src/apis/product.ts
+++ b/src/apis/product.ts
@@ -30,6 +30,13 @@ const getProductById = async (productId: number) => {
   });
 };
 
+const getProductByPartner = async (partnerId: number) => {
+  return instance({
+    url: `/product/user/${partnerId}`,
+    method: 'GET',
+  });
+};
+
 const putProduct = async (
   productId: number,
   userId: number,
@@ -73,6 +80,7 @@ const postProduct = async (
 export default {
   getProductAll,
   getProductById,
+  getProductByPartner,
   putProduct,
   deleteProductById,
   postProduct,

--- a/src/components/ReservedManageCard.tsx
+++ b/src/components/ReservedManageCard.tsx
@@ -7,6 +7,7 @@ import {
   ReserveStatusType,
 } from '@/constants/reserveType';
 import instance from '@/utils/axios';
+import { useState } from 'react';
 import Button from '@/components/common/Button';
 import ReservationCard from '@/components/common/reservPagination/ResevationCard';
 import ReservChips from '@/components/myPage/ReservChips';
@@ -38,16 +39,21 @@ const ReservedManageCard = ({
   reserveDate = '',
   timeTable = { targetDate: '', startTimeOnly: '', endTimeOnly: '' },
 }: ReserveProps) => {
+  const [state, setState] = useState<ReserveStatusType>(reservationState);
+
   const handleApprove = () => {
     instance.put(`/reservation/${id}`, { reservationState: '예약 완료' });
+    setState('예약 완료');
   };
 
   const handleReject = () => {
     instance.put(`/reservation/${id}`, { reservationState: '예약 거절' });
+    setState('예약 거절');
   };
 
   const handleStandby = () => {
     instance.put(`/reservation/${id}`, { reservationState: '예약 대기' });
+    setState('예약 대기');
   };
 
   return (
@@ -59,9 +65,9 @@ const ReservedManageCard = ({
       // schedule={`일정 : ${changeDateForm(timeTable.targetDate)}, ${timeTable.startTimeOnly} ~ ${timeTable.endTimeOnly}`}
       time={timeTable}
       userInfo={`예약자명 : ${user.name} / 전화번호 : ${user.phone}`}
-      upperRight={<ReservChips status={reservationState} />}
+      upperRight={<ReservChips status={state} />}
       lowerRight={
-        reservationState === '예약 대기' ? (
+        state === '예약 대기' ? (
           <div className="flex flex-col mobile:flex-row gap-8 justify-end">
             <div className="absolute top-16 right-16 text-14 text-right font-semibold">
               대기중
@@ -95,7 +101,7 @@ const ReservedManageCard = ({
               <ReservButtonOutlined status="예약 거절" onClick={handleReject} />
             </div>
           </div>
-        ) : reservationState === '예약 완료' ? (
+        ) : state === '예약 완료' ? (
           <div className="flex flex-col gap-8 justify-between">
             <div className="absolute top-16 right-16 text-14 text-right font-semibold">
               승인됨
@@ -125,7 +131,7 @@ const ReservedManageCard = ({
               <ReservButtonOutlined status="예약 거절" onClick={handleReject} />
             </div>
           </div>
-        ) : reservationState === '예약 거절' ? (
+        ) : state === '예약 거절' ? (
           <div className="flex flex-col gap-8 justify-between">
             <div className="absolute top-16 right-16 text-14 text-right font-semibold">
               거절됨
@@ -153,7 +159,7 @@ const ReservedManageCard = ({
               </Button>
             </div>
           </div>
-        ) : reservationState === '예약 취소' ? (
+        ) : state === '예약 취소' ? (
           <div className="flex flex-col gap-8 justify-between">
             <div className="absolute top-16 right-16 text-14 text-right font-semibold">
               예약 취소함

--- a/src/components/myPage/MyPageSideBar.tsx
+++ b/src/components/myPage/MyPageSideBar.tsx
@@ -31,7 +31,10 @@ const MyPageSideBar = ({ children, isPartner = false }: MyPageSideBarProps) => {
   const buttonList = [
     { status: 'edit-info', text: '정보 수정' },
     ...(isPartner
-      ? [{ status: 'manage', text: '예약 관리' }]
+      ? [
+          { status: 'posting-manage', text: '게시물 관리' },
+          { status: 'reserve-manage', text: '예약 관리' },
+        ]
       : [
           { status: 'reservation-status', text: '예약 현황' },
           { status: 'reservation-history', text: '예약 내역' },

--- a/src/hooks/reactQuery/product/useProductByPartnerQuery.ts
+++ b/src/hooks/reactQuery/product/useProductByPartnerQuery.ts
@@ -1,0 +1,19 @@
+import productApi from '@/apis/product';
+import { useQuery } from '@tanstack/react-query';
+
+const useProductByPartnerQuery = (partnerId: number) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['getProductByPartner', partnerId],
+    queryFn: () => productApi.getProductByPartner(partnerId),
+  });
+
+  const postingData = data?.data ?? [];
+
+  return {
+    postingData,
+    isLoading,
+    error,
+  };
+};
+
+export default useProductByPartnerQuery;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -7,6 +7,7 @@ import MyResevation from '@/components/myPage/MyResevation';
 import ReservationManagement from '@/pages/ReservationManagement';
 import Footer from '@/components/common/Footer';
 import Layout from '@/components/common/layout/Layout';
+import PostingManagement from './PostingManagement';
 
 const MyPage = ({ isPartner = false }: { isPartner?: boolean }) => {
   const { status } = useParams();
@@ -27,7 +28,8 @@ const MyPage = ({ isPartner = false }: { isPartner?: boolean }) => {
           {status === 'reservation-history' && (
             <MyResevation isExpired="true" />
           )}
-          {status === 'manage' && <ReservationManagement />}
+          {status === 'posting-manage' && <PostingManagement />}
+          {status === 'reserve-manage' && <ReservationManagement />}
         </MyPageSideBar>
       </Layout>
       <Footer />

--- a/src/pages/PartnerMain.tsx
+++ b/src/pages/PartnerMain.tsx
@@ -1,7 +1,10 @@
+import { useNavigate } from 'react-router-dom';
 import PartnerMainButton from '@/components/PartnerMainButton';
 import Layout from '@/components/common/layout/Layout';
 
 const PartnerMain = () => {
+  const navigate = useNavigate();
+
   return (
     <Layout noSearch category={false}>
       <div className="flex flex-col py-16 items-center">
@@ -10,10 +13,19 @@ const PartnerMain = () => {
           <span className="mobile:text-22">무엇을 도와드릴까요?</span>
         </div>
         <div className="flex mobile:flex-col mobile:w-full py-20 gap-20">
-          <PartnerMainButton text="내 게시물 목록 보기" />
-          <PartnerMainButton text="예약 관리" />
+          <PartnerMainButton
+            text="내 게시물 목록 보기"
+            onClick={() => navigate('/partner/mypage/edit-info')}
+          />
+          <PartnerMainButton
+            text="예약 관리"
+            onClick={() => navigate('/partner/mypage/posting-manage')}
+          />
           <PartnerMainButton text="내 사업자 등록증" />
-          <PartnerMainButton text="판매자 정보 수정" />
+          <PartnerMainButton
+            text="판매자 정보 수정"
+            onClick={() => navigate('/partner/mypage/reserve-manage')}
+          />
         </div>
       </div>
     </Layout>

--- a/src/pages/PostingManagement.tsx
+++ b/src/pages/PostingManagement.tsx
@@ -1,10 +1,10 @@
 import ARROW from '@/assets/icons/arrowDown.svg';
 import { useEffect, useState } from 'react';
 import { useUserStore } from '@/utils/zustand';
-import useReservationManageQuery from '@/hooks/reactQuery/reservation/useReservationManageQuery';
+import useProductByPartnerQuery from '@/hooks/reactQuery/product/useProductByPartnerQuery';
 import SearchBar from '@/components/common/SearchBar';
-import ReservedManageCard from '@/components/ReservedManageCard';
 import ReservPagination from '@/components/common/reservPagination/ReservPagination';
+import ReservationCard from '@/components/common/reservPagination/ResevationCard';
 
 const PostingManagement = () => {
   const { userInfo } = useUserStore();
@@ -14,15 +14,7 @@ const PostingManagement = () => {
   const [activityData, setActivityData] = useState<any[]>([]);
   const [allData, setAllData] = useState<any[]>([]);
 
-  const { reservedData: lodge } = useReservationManageQuery({
-    partnerId: userInfo.id,
-    categoryId: 1,
-  });
-
-  const { reservedData: activity, error: acError } = useReservationManageQuery({
-    partnerId: userInfo.id,
-    categoryId: 2,
-  });
+  const { postingData: allPost } = useProductByPartnerQuery(userInfo.id);
 
   const sortData = (data: any[], postNew: boolean) => {
     if (!Array.isArray(data)) return [];
@@ -32,7 +24,7 @@ const PostingManagement = () => {
       return postNew ? timeB - timeA : timeA - timeB;
     });
   };
-  console.log(acError);
+
   const toggleDropdown = () => {
     setIsNew(!isNew);
   };
@@ -68,12 +60,18 @@ const PostingManagement = () => {
   const end = start + limit;
 
   useEffect(() => {
-    setLodgeData(sortData(lodge, isNew));
-    setActivityData(sortData(activity, isNew));
-    setAllData(sortData([...lodge, ...activity], isNew));
+    setAllData(sortData(allPost, isNew));
+    if (allPost) {
+      const lodge = allPost.filter(
+        (post: { categoryId: number }) => post.categoryId === 1,
+      );
+      const activity = allPost.filter(
+        (post: { categoryId: number }) => post.categoryId === 2,
+      );
+      setLodgeData(sortData(lodge, isNew));
+      setActivityData(sortData(activity, isNew));
+    }
   }, [isNew, allData]);
-
-  sortData(activity, isNew);
 
   return (
     <div className="mx-10 my-0 w-1000">
@@ -141,14 +139,11 @@ const PostingManagement = () => {
                     allCardNum={allData.length}
                   >
                     {allData.slice(start, end).map((item) => (
-                      <ReservedManageCard
+                      <ReservationCard
                         key={item.id}
                         id={item.id}
-                        reservationState={item.reservationState}
-                        productOption={item.productOption}
-                        user={item.user}
-                        reserveDate={item.createdAt}
-                        timeTable={item.timeTable}
+                        title={item.name}
+                        date={item.createdAt}
                       />
                     ))}
                   </ReservPagination>
@@ -166,14 +161,11 @@ const PostingManagement = () => {
                     allCardNum={lodgeData.length}
                   >
                     {lodgeData.slice(start, end).map((item) => (
-                      <ReservedManageCard
+                      <ReservationCard
                         key={item.id}
                         id={item.id}
-                        reservationState={item.reservationState}
-                        productOption={item.productOption}
-                        user={item.user}
-                        reserveDate={item.createdAt}
-                        timeTable={item.timeTable}
+                        title={item.name}
+                        date={item.createdAt}
                       />
                     ))}
                   </ReservPagination>
@@ -191,14 +183,11 @@ const PostingManagement = () => {
                     allCardNum={activityData.length}
                   >
                     {activityData.slice(start, end).map((item) => (
-                      <ReservedManageCard
+                      <ReservationCard
                         key={item.id}
                         id={item.id}
-                        reservationState={item.reservationState}
-                        productOption={item.productOption}
-                        user={item.user}
-                        reserveDate={item.createdAt}
-                        timeTable={item.timeTable}
+                        title={item.name}
+                        date={item.createdAt}
                       />
                     ))}
                   </ReservPagination>

--- a/src/pages/PostingManagement.tsx
+++ b/src/pages/PostingManagement.tsx
@@ -71,7 +71,7 @@ const PostingManagement = () => {
     setLodgeData(sortData(lodge, isNew));
     setActivityData(sortData(activity, isNew));
     setAllData(sortData([...lodge, ...activity], isNew));
-  }, [isNew]);
+  }, [isNew, allData]);
 
   sortData(activity, isNew);
 
@@ -79,7 +79,7 @@ const PostingManagement = () => {
     <div className="mx-10 my-0 w-1000">
       <div className="flex flex-col gap-60 mt-60">
         <div className="flex flex-col gap-20">
-          <div className="font-bold text-24">예약 관리</div>
+          <div className="font-bold text-24">상품 판매(게시) 관리</div>
           <SearchBar cardLists={[]} />
         </div>
 
@@ -154,7 +154,7 @@ const PostingManagement = () => {
                   </ReservPagination>
                 ) : (
                   <div className="flex items-center justify-center text-24 font-medium">
-                    예약 내역이 없습니다.
+                    게시한 상품이 없습니다.
                   </div>
                 ))}
               {selectedCategory === '숙박' &&
@@ -179,7 +179,7 @@ const PostingManagement = () => {
                   </ReservPagination>
                 ) : (
                   <div className="flex items-center justify-center text-24 font-medium">
-                    예약 내역이 없습니다.
+                    게시한 상품이 없습니다.
                   </div>
                 ))}
               {selectedCategory === '체험' &&
@@ -204,7 +204,7 @@ const PostingManagement = () => {
                   </ReservPagination>
                 ) : (
                   <div className="flex items-center justify-center text-24 font-medium">
-                    예약 내역이 없습니다.
+                    게시한 상품이 없습니다.
                   </div>
                 ))}
 

--- a/src/pages/ReservationManagement.tsx
+++ b/src/pages/ReservationManagement.tsx
@@ -19,7 +19,7 @@ const ReservationManagement = () => {
     categoryId: 1,
   });
 
-  const { reservedData: activity, error: acError } = useReservationManageQuery({
+  const { reservedData: activity } = useReservationManageQuery({
     partnerId: userInfo.id,
     categoryId: 2,
   });
@@ -32,7 +32,7 @@ const ReservationManagement = () => {
       return postNew ? timeB - timeA : timeA - timeB;
     });
   };
-  console.log(acError);
+
   const toggleDropdown = () => {
     setIsNew(!isNew);
   };

--- a/src/pages/ReservationManagement.tsx
+++ b/src/pages/ReservationManagement.tsx
@@ -33,7 +33,7 @@ const ReservationManagement = () => {
     });
   };
 
-  const toggleDropdown = () => {
+  const toggleOrder = () => {
     setIsNew(!isNew);
   };
 
@@ -68,12 +68,13 @@ const ReservationManagement = () => {
   const end = start + limit;
 
   useEffect(() => {
-    setLodgeData(sortData(lodge, isNew));
-    setActivityData(sortData(activity, isNew));
-    setAllData(sortData([...lodge, ...activity], isNew));
-  }, [isNew]);
-
-  sortData(activity, isNew);
+    const fetchData = () => {
+      setLodgeData(sortData(lodge, isNew));
+      setActivityData(sortData(activity, isNew));
+      setAllData(sortData([...lodge, ...activity], isNew));
+    };
+    fetchData();
+  }, [isNew, allData]);
 
   return (
     <div className="mx-10 my-0 w-1000">
@@ -103,7 +104,7 @@ const ReservationManagement = () => {
               className="flex items-center justify-center gap-4 
               px-12 py-8 text-16 font-semibold
               border-1 border-solid border-black-5 rounded-8"
-              onClick={toggleDropdown}
+              onClick={toggleOrder}
             >
               {isNew ? (
                 <>


### PR DESCRIPTION
## 🚀 작업 내용

- 파트너 게시물 관리 페이지 구현 및 관련 API, Hook 추가
    - 페이지 시간순 정렬, 카테고리별 분리 구현
    - API : getProductByPartner GET 메서드 추가
    - Hook : useProductByPartnerQuery React Query Hook 추가
- 사이드바 항목 추가 및 링크 수정
    - 게시물 관리 : /partner/mypage/posting-manage
    - 예약 관리 : /partner/mypage/reserve-manage
- 게시물 관리, 예약 관리 페이지 렌더링 관련 문제 해결
    - 새로고침 시, 초기에 데이터들이 렌더링 되지 않는 문제 해결
    - 예약 승인, 거절 등의 버튼을 눌렀을 때 state가 실시간으로 반영되지 않는 문제 해결
- 파트너 메인 페이지 버튼 별 클릭 시 해당하는 페이지로 링크 설정


## 📝 참고 사항

- 페이지 디자인은 완성되지 않은 것입니다! 수정 예정이니 디자인은 우선 배제해주세요!

## 🖼️ 스크린샷

**<상품 게시 관리 페이지>**
![상품 게시 관리](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/88cc622e-a547-41c7-9ec4-e6019ef3421f)

**<정렬(최신순)>**
![정렬(최신순)](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/a9be34bf-3d1e-48fc-a0f7-ee0523738c84)

**<정렬(과거순)>**
![정렬(과거순)](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/4bc6be35-be87-4d72-b915-e75de66d06c6)

## 🚨 관련 이슈

- close-#(issue_number)
