### PR TITLE
[Refactor] 디테일 페이지 경로 수정 및 로그인 안된 유저 페이지 겁근 막는 컴포넌트 추가 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import NoPage from '@/pages/NoPage';
 import PreparingPage from '@/pages/PreparingPage';
 import Cart from '@/pages/Cart';
 import CheckoutCartPage from '@/pages/payments/CheckoutCartPage';
+import ProtectedRoute from './components/ProtectedRoute';
 
 const App = () => {
   return (
@@ -53,10 +54,38 @@ const App = () => {
           <Route path="product-register" element={<ProductRegister />} />
         </Route>
         <Route path="payments">
-          <Route index element={<CheckoutPage />} />
-          <Route path="cart" element={<CheckoutCartPage />} />
-          <Route path="success" element={<SuccessPage />} />
-          <Route path="fail" element={<FailPage />} />
+          <Route
+            index
+            element={
+              <ProtectedRoute>
+                <CheckoutPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="cart"
+            element={
+              <ProtectedRoute>
+                <CheckoutCartPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="success"
+            element={
+              <ProtectedRoute>
+                <SuccessPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="fail"
+            element={
+              <ProtectedRoute>
+                <FailPage />
+              </ProtectedRoute>
+            }
+          />
         </Route>
         <Route path="review/:optionId">
           <Route index element={<ReviewRegist />} />
@@ -64,7 +93,14 @@ const App = () => {
         <Route path="search">
           <Route index element={<SearchResultPage />} />
         </Route>
-        <Route path="cart" element={<Cart />} />
+        <Route
+          path="cart"
+          element={
+            <ProtectedRoute>
+              <Cart />
+            </ProtectedRoute>
+          }
+        />
         <Route path="*" element={<NoPage />} />
         {/* 서비스 준비중 페이지  */}
         <Route path="preparing" element={<PreparingPage />} />

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,13 @@
+import { useUserStore } from '@/utils/zustand';
+import { Navigate } from 'react-router-dom';
+
+const ProtectedRoute = ({ children }: any) => {
+  const { userInfo } = useUserStore();
+
+  if (userInfo.id === 0) {
+    return <Navigate to="/" />;
+  }
+
+  return children;
+};
+export default ProtectedRoute;

--- a/src/components/SearchResultSection.tsx
+++ b/src/components/SearchResultSection.tsx
@@ -37,7 +37,7 @@ const ProductCard = ({
       score={scoreAvg}
       review={reviewCount}
       image={thumbnail}
-      link={`/detail/${product_categoryId}/${id}`}
+      link={`/details/${product_categoryId}/${id}`}
     />
   );
 };

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -61,7 +61,7 @@ const Main = () => {
       data.map((item: any) => ({
         url: item.thumbnail,
         text: item.productName,
-        path: `detail/${categoryId}/${item.productId}`,
+        path: `details/${categoryId}/${item.productId}`,
         location: item.productAddress,
         price: item.minPrice,
         score: item.reviewAvg.toFixed(1),


### PR DESCRIPTION
## 🚀 작업 내용

- 디테일 페이지로 가는 경로 수정 
- 로그인 안된 유저가 로그인 하고 봐야할 페이지에 접근 시 메인 페이지로 이동하게 하기

## 📝 참고 사항

로그인 안된 유저가 로그인 하고 봐야할 페이지에 접근 시에 메인 페이지로 이동해야 하는 페이지가 있다면` <ProtectedRoute> `컴포넌트를 만들어뒀으니,` App.tsx`파일에서 

<img width="392" alt="스크린샷 2024-06-17 오전 10 52 46" src="https://github.com/sprint4-part4-team7/TravelPort-49105/assets/114905530/0a3cc683-71ae-491a-886e-ddc141a2616c">

위 사진처럼 element에 해당 컴포넌트를 ` <ProtectedRoute> `컴포넌트로 감싸주기만 하면 됩니다 !

## 🖼️ 스크린샷

## 🚨 관련 이슈

- close-#(issue_number)
