### PR TITLE
[Fix] 프로필 이미지 변경 시 헤더 프로필 적용 안되는 이슈 해결

### DIFF
--- a/src/components/myPage/EditInfo.tsx
+++ b/src/components/myPage/EditInfo.tsx
@@ -49,6 +49,7 @@ const EditInfo = ({ isPartner = false }: { isPartner?: boolean }) => {
   };
 
   const handleSave = async (data: UserInfo) => {
+    localStorage.removeItem('profileImage');
     if (img.length) {
       const response = await postImages(img, BUCKER_NAME.PRODUCT_OPTION);
       data = { ...data, profileImage: response[0] };


### PR DESCRIPTION
## 🚀 작업 내용

- 프로필 이미지 변경 시 헤더 프로필 적용 안되는 이슈 해결
- handleSave 함수에 `localStorage.removeItem('profileImage');` 적용

## 📝 참고 사항

-

## 🖼️ 스크린샷

https://github.com/sprint4-part4-team7/TravelPort-49105/assets/114905530/fbdeecc8-03ef-473e-9da6-470eb33ad9da


## 🚨 관련 이슈

- close-#(issue_number)
