### PR TITLE
[Fix] 결제 페이지 reservation api 두번 요청되는 이슈 해결 

### DIFF
--- a/src/components/common/headerBar/LoginUserHeaderBar.tsx
+++ b/src/components/common/headerBar/LoginUserHeaderBar.tsx
@@ -110,13 +110,13 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
             id: 'reservation-status',
             icon: list,
             label: '예약 내역',
-            path: '/mypage/reservation-status',
+            path: '/mypage/reservation-history',
           },
           {
             id: 'reservation-history',
             icon: reservationStatus,
             label: '예약 현황',
-            path: '/mypage/resevation-history',
+            path: '/mypage/reservation-status',
           },
         ]
       : []),
@@ -136,13 +136,13 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
             id: 'reservation-status',
             icon: list,
             label: '예약 내역',
-            path: '/mypage/resevation-status',
+            path: '/mypage/reservation-history',
           },
           {
             id: 'reservation-history',
             icon: reservationStatus,
             label: '예약 현황',
-            path: '/mypage/resevation-history',
+            path: '/mypage/reservation-status',
           },
         ]
       : []),
@@ -159,18 +159,18 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
           <img
             src={user.image}
             alt="Profile"
-            className="rounded-full cursor-pointer h-32 w-32"
+            className="w-32 h-32 rounded-full cursor-pointer"
           />
         </button>
         {userInfo.isPartner === 0 && (
           <button type="button" onClick={() => navagate('/cart')}>
-            <img className="h-32 w-32" src={cart} alt="쇼핑 카트 아이콘" />
+            <img className="w-32 h-32" src={cart} alt="쇼핑 카트 아이콘" />
           </button>
         )}
       </div>
       <div className="hidden mobile:flex">
         <button type="button" onClick={toggleSidebar}>
-          <img src={menu} alt="Menu" className="h-32 w-32 cursor-pointer" />
+          <img src={menu} alt="Menu" className="w-32 h-32 cursor-pointer" />
         </button>
       </div>
       {isDropdownOpen && (
@@ -186,7 +186,7 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
                 <img
                   src={user.image}
                   alt="Profile"
-                  className="rounded-full h-32 w-32 mobile:w-26 mobile:h-26"
+                  className="w-32 h-32 rounded-full mobile:w-26 mobile:h-26"
                 />
                 <span className="ml-2">{user.name}</span>
               </div>
@@ -196,7 +196,7 @@ const LoginUserHeaderBar: React.FC<LoginUserHeaderBarProps> = ({
               <li className="items-center justify-between hidden px-12 mobile:flex py-1.5 hover:bg-blue-50">
                 <div className="flex items-center">
                   <img
-                    className="h-32 w-32 mobile:w-16 mobile:h-16"
+                    className="w-32 h-32 mobile:w-16 mobile:h-16"
                     src={cart}
                     alt="쇼핑 카트 아이콘"
                   />

--- a/src/pages/payments/SuccessPage.tsx
+++ b/src/pages/payments/SuccessPage.tsx
@@ -29,6 +29,8 @@ const SuccessPage = () => {
 
   const [isInitialized, setIsInitialized] = useState(false);
   const [isReservationWhitPay, setIsReservationWhitPay] = useState(false);
+  const [isCartReservationCompleted, setIsCartReservationCompleted] =
+    useState(false);
 
   const confirm = () => {
     navigate('/');
@@ -59,11 +61,12 @@ const SuccessPage = () => {
         userId,
         cartIds,
       });
+      setIsCartReservationCompleted(true);
     }
   };
 
   const handleReservationPost = async () => {
-    if (!isReservationWhitPay) {
+    if (!isReservationWhitPay && !isCartReservationCompleted) {
       createReservation({
         userId: reservationInfo.userId,
         productOptionId: reservationInfo.productOptionId,
@@ -100,10 +103,11 @@ const SuccessPage = () => {
   }, [cartData, pId]);
 
   useEffect(() => {
-    if (cartInfo.length === 0 && reservationInfo.productOptionId !== 0) {
+    if (cartInfo.length === 0 && !isCartReservationCompleted) {
+      // Check if cart reservation is not completed
       handleReservationPost();
     }
-  }, [cartInfo, reservationInfo]);
+  }, [cartInfo, isCartReservationCompleted]);
 
   useEffect(() => {
     handlePaymentPut(payId);
@@ -121,7 +125,11 @@ const SuccessPage = () => {
             <img src={check} alt="성공 아이콘" />
             <div className="mt-32 font-bold text-32">결제가 완료되었습니다</div>
             <div className="flex w-full gap-28 mt-100 mobile:flex-col">
-              <Button outlined buttonStyle="w-320 h-48 text-16 font-normal">
+              <Button
+                outlined
+                onClick={() => navigate('/mypage/reservation-status')}
+                buttonStyle="w-320 h-48 text-16 font-normal"
+              >
                 내 예약 현황으로
               </Button>
               <Button


### PR DESCRIPTION
## 🚀 작업 내용

- 헤더바 및 결제 완료 페이지에서 나오는 결제 내역, 결제 현황 보러가는 경로 수정
- 결제 페이지 reservation api 두번 요청되는 이슈 해결 

## 📝 참고 사항

-

## 🖼️ 스크린샷

## 🚨 관련 이슈

- close-#(issue_number)
