### PR TITLE
[Fix] switch on/off, 삭제하기 동작 후 내용이 바로 반영되도록 수정, 예약 관리-예약 거절 시 '취소하기' 버튼 삭제 외

### DIFF
--- a/src/components/PostingCard.tsx
+++ b/src/components/PostingCard.tsx
@@ -1,34 +1,38 @@
 import changeDateForm from '@/utils/changeDateForm';
-import { ReactNode } from 'react';
+import useModal from '@/hooks/useModal';
+import ReservButtonOutlined from '@/components/myPage/ReservButtonOutlined';
+import DeletePosting from '@/components/myPage/Modal/DeletePosting';
+import PostingSwitch from '@/components/myPage/PostingSwitch';
 
 interface PostingCardProps {
   id: number;
   title: string;
   postingDate: string;
+  postingState: boolean;
   salePeriod?: {
     startDate: string;
     endDate: string;
   };
   option?: string;
-  upperRight?: ReactNode;
-  lowerRight?: ReactNode;
 }
 
 const PostingCard = ({
   id = 0,
   title,
   postingDate,
+  postingState,
   salePeriod,
   option,
-  upperRight,
-  lowerRight,
 }: PostingCardProps) => {
+  const { isModalOpen, openModal, closeModal } = useModal();
+
   const duration =
     salePeriod?.startDate && salePeriod?.endDate
       ? `${changeDateForm(salePeriod?.startDate)} ~ ${changeDateForm(salePeriod?.endDate)}`
       : salePeriod?.startDate || salePeriod?.endDate || '';
   const salePeriodStr = `판매 기간 : ${duration}`;
   const postingDateStr = `게시일 : ${changeDateForm(postingDate)}`;
+
   return (
     <div
       id={id ? id.toString() : 'undefined'}
@@ -38,7 +42,9 @@ const PostingCard = ({
         <div className="flex flex-col gap-12">
           <div className="flex flex-row font-semibold justify-between">
             <div className="text-20 font-semibold">상품명 : {title}</div>
-            <div className="text-16 font-semibold">{upperRight}</div>
+            <div className="text-16 font-semibold">
+              <PostingSwitch id={id} state={postingState} />
+            </div>
           </div>
           <div className="flex flex-col gap-6">
             {option && (
@@ -51,7 +57,8 @@ const PostingCard = ({
         </div>
         <div className="flex flex-row justify-between items-center">
           <div className="text-16">{postingDateStr}</div>
-          {lowerRight}
+          <ReservButtonOutlined status={5} onClick={openModal} />
+          <DeletePosting id={id} closeModal={closeModal} isOpen={isModalOpen} />
         </div>
       </div>
     </div>

--- a/src/components/PostingCard.tsx
+++ b/src/components/PostingCard.tsx
@@ -1,5 +1,6 @@
 import changeDateForm from '@/utils/changeDateForm';
 import useModal from '@/hooks/useModal';
+import { useNavigate } from 'react-router-dom';
 import ReservButtonOutlined from '@/components/myPage/ReservButtonOutlined';
 import DeletePosting from '@/components/myPage/Modal/DeletePosting';
 import PostingSwitch from '@/components/myPage/PostingSwitch';
@@ -24,6 +25,7 @@ const PostingCard = ({
   salePeriod,
   option,
 }: PostingCardProps) => {
+  const navigate = useNavigate();
   const { isModalOpen, openModal, closeModal } = useModal();
 
   const duration =
@@ -36,13 +38,20 @@ const PostingCard = ({
   return (
     <div
       id={id ? id.toString() : 'undefined'}
-      className="flex flex-col p-16 w-full max-w-834 gap-32 border-1 border-black-5 rounded-8"
+      className="flex flex-col p-16 w-full max-w-834 gap-32 
+      border-1 border-black-5 rounded-8
+      cursor-pointer hover:bg-black-2 active:bg-black-1
+      "
+      onClick={() => navigate('/partner/product-register')}
     >
       <div className="flex flex-col justify-between gap-32">
         <div className="flex flex-col gap-12">
           <div className="flex flex-row font-semibold justify-between">
             <div className="text-20 font-semibold">상품명 : {title}</div>
-            <div className="text-16 font-semibold">
+            <div
+              className="text-16 font-semibold"
+              onClick={(e) => e.stopPropagation()}
+            >
               <PostingSwitch id={id} state={postingState} />
             </div>
           </div>
@@ -57,8 +66,14 @@ const PostingCard = ({
         </div>
         <div className="flex flex-row justify-between items-center">
           <div className="text-16">{postingDateStr}</div>
-          <ReservButtonOutlined status={5} onClick={openModal} />
-          <DeletePosting id={id} closeModal={closeModal} isOpen={isModalOpen} />
+          <div onClick={(e) => e.stopPropagation()}>
+            <ReservButtonOutlined status={5} onClick={openModal} />
+            <DeletePosting
+              id={id}
+              closeModal={closeModal}
+              isOpen={isModalOpen}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ReservedManageCard.tsx
+++ b/src/components/ReservedManageCard.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable no-nested-ternary */
-// import DENIED from '@/assets/icons/x-square-red.svg';
-// import CANCEL from '@/assets/icons/x-square.svg';
 import { ReservProductOptionType, ReservStatusType } from '@/constants/types';
 import instance from '@/utils/axios';
 import { useState } from 'react';
@@ -71,7 +69,6 @@ const ReservedManageCard = ({
       title={productOption.product.name}
       date={reserveDate}
       option={productOption.optionName}
-      // schedule={`일정 : ${changeDateForm(timeTable.targetDate)}, ${timeTable.startTimeOnly} ~ ${timeTable.endTimeOnly}`}
       time={timeTable}
       userInfo={`예약자명 : ${user.name} / 전화번호 : ${user.phone}`}
       upperRight={<ReservChips status={state} />}
@@ -108,7 +105,6 @@ const ReservedManageCard = ({
               거절됨
             </div>
             <div className="flex gap-8 items-end tablet:flex-col mobile:justify-between">
-              <ReservButtonOutlined status={4} onClick={handleStandby} />
               <Button
                 variant="default"
                 outlined

--- a/src/components/myPage/Modal/DeletePosting.tsx
+++ b/src/components/myPage/Modal/DeletePosting.tsx
@@ -1,4 +1,5 @@
 import useProductDeleteMutation from '@/hooks/reactQuery/product/useProductDeleteMutation';
+import { toast } from 'react-toastify';
 import DefaultModal from '@/components/common/DefaultModal';
 
 const DeletePosting = ({
@@ -14,6 +15,7 @@ const DeletePosting = ({
 
   const handleDelete = () => {
     mutate(productId);
+    toast.success('게시물이 삭제되었습니다.');
     closeModal();
   };
   return (

--- a/src/hooks/reactQuery/product/usePostingStateMutation.ts
+++ b/src/hooks/reactQuery/product/usePostingStateMutation.ts
@@ -20,7 +20,7 @@ const usePostingStateMutation = () => {
     },
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: ['postingStateMutation'],
+        queryKey: ['getProductByPartner'],
       });
     },
   });

--- a/src/hooks/reactQuery/product/useProductDeleteMutation.ts
+++ b/src/hooks/reactQuery/product/useProductDeleteMutation.ts
@@ -10,7 +10,7 @@ const useProductDeleteMutation = () => {
     },
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: ['ProductDeleteMutation'],
+        queryKey: ['getProductByPartner'],
       });
     },
   });

--- a/src/pages/PostingManagement.tsx
+++ b/src/pages/PostingManagement.tsx
@@ -2,15 +2,9 @@ import ARROW from '@/assets/icons/arrowDown.svg';
 import { useEffect, useState } from 'react';
 import { useUserStore } from '@/utils/zustand';
 import useProductByPartnerQuery from '@/hooks/reactQuery/product/useProductByPartnerQuery';
-// import useModal from '@/hooks/useModal';
-import useProductDeleteMutation from '@/hooks/reactQuery/product/useProductDeleteMutation';
-import { toast } from 'react-toastify';
 import SearchBar from '@/components/common/SearchBar';
 import ReservPagination from '@/components/common/reservPagination/ReservPagination';
 import PostingCard from '@/components/PostingCard';
-import PostingSwitch from '@/components/myPage/PostingSwitch';
-import ReservButtonOutlined from '@/components/myPage/ReservButtonOutlined';
-// import DeletePosting from '@/components/myPage/Modal/DeletePosting';
 
 const PostingManagement = () => {
   const { userInfo } = useUserStore();
@@ -21,7 +15,6 @@ const PostingManagement = () => {
   const [allData, setAllData] = useState<any[]>([]);
 
   const { postingData: allPost } = useProductByPartnerQuery(userInfo.id);
-  // const { isModalOpen, openModal, closeModal } = useModal();
 
   const sortData = (data: any[], postNew: boolean) => {
     if (!Array.isArray(data)) return [];
@@ -38,13 +31,6 @@ const PostingManagement = () => {
 
   const handleCategoryClick = (category: string) => {
     setSelectedCategory(category);
-  };
-
-  const { mutate } = useProductDeleteMutation();
-
-  const handleDelete = (productId: number) => {
-    mutate(productId);
-    toast.success('게시물이 삭제되었습니다.');
   };
 
   const getCategoryCount = (category: string) => {
@@ -153,36 +139,17 @@ const PostingManagement = () => {
                     allCardNum={allData.length}
                   >
                     {allData.slice(start, end).map((item) => (
-                      <div key={item.id}>
-                        <PostingCard
-                          id={item.id}
-                          title={item.name}
-                          salePeriod={{
-                            startDate: item.startDate,
-                            endDate: item.endDate,
-                          }}
-                          postingDate={item.createdAt}
-                          upperRight={
-                            <PostingSwitch
-                              id={item.id}
-                              state={item.isPosting}
-                            />
-                          }
-                          lowerRight={
-                            <>
-                              <ReservButtonOutlined
-                                status={5}
-                                onClick={() => handleDelete(item.id)}
-                              />
-                              {/* <DeletePosting
-                                id={item.id}
-                                closeModal={closeModal}
-                                isOpen={isModalOpen}
-                              /> */}
-                            </>
-                          }
-                        />
-                      </div>
+                      <PostingCard
+                        key={item.id}
+                        id={item.id}
+                        title={item.name}
+                        salePeriod={{
+                          startDate: item.startDate,
+                          endDate: item.endDate,
+                        }}
+                        postingDate={item.createdAt}
+                        postingState={item.isPosting}
+                      />
                     ))}
                   </ReservPagination>
                 ) : (
@@ -199,36 +166,17 @@ const PostingManagement = () => {
                     allCardNum={lodgeData.length}
                   >
                     {lodgeData.slice(start, end).map((item) => (
-                      <div key={item.id}>
-                        <PostingCard
-                          id={item.id}
-                          title={item.name}
-                          salePeriod={{
-                            startDate: item.startDate,
-                            endDate: item.endDate,
-                          }}
-                          postingDate={item.createdAt}
-                          upperRight={
-                            <PostingSwitch
-                              id={item.id}
-                              state={item.isPosting}
-                            />
-                          }
-                          lowerRight={
-                            <>
-                              <ReservButtonOutlined
-                                status={5}
-                                onClick={() => handleDelete(item.id)}
-                              />
-                              {/* <DeletePosting
-                                id={item.id}
-                                closeModal={closeModal}
-                                isOpen={isModalOpen}
-                              /> */}
-                            </>
-                          }
-                        />
-                      </div>
+                      <PostingCard
+                        key={item.id}
+                        id={item.id}
+                        title={item.name}
+                        salePeriod={{
+                          startDate: item.startDate,
+                          endDate: item.endDate,
+                        }}
+                        postingDate={item.createdAt}
+                        postingState={item.isPosting}
+                      />
                     ))}
                   </ReservPagination>
                 ) : (
@@ -245,36 +193,17 @@ const PostingManagement = () => {
                     allCardNum={activityData.length}
                   >
                     {activityData.slice(start, end).map((item) => (
-                      <div key={item.id}>
-                        <PostingCard
-                          id={item.id}
-                          title={item.name}
-                          salePeriod={{
-                            startDate: item.startDate,
-                            endDate: item.endDate,
-                          }}
-                          postingDate={item.createdAt}
-                          upperRight={
-                            <PostingSwitch
-                              id={item.id}
-                              state={item.isPosting}
-                            />
-                          }
-                          lowerRight={
-                            <>
-                              <ReservButtonOutlined
-                                status={5}
-                                onClick={() => handleDelete(item.id)}
-                              />
-                              {/* <DeletePosting
-                                id={item.id}
-                                closeModal={closeModal}
-                                isOpen={isModalOpen}
-                              /> */}
-                            </>
-                          }
-                        />
-                      </div>
+                      <PostingCard
+                        key={item.id}
+                        id={item.id}
+                        title={item.name}
+                        salePeriod={{
+                          startDate: item.startDate,
+                          endDate: item.endDate,
+                        }}
+                        postingDate={item.createdAt}
+                        postingState={item.isPosting}
+                      />
                     ))}
                   </ReservPagination>
                 ) : (

--- a/src/pages/PostingManagement.tsx
+++ b/src/pages/PostingManagement.tsx
@@ -2,13 +2,15 @@ import ARROW from '@/assets/icons/arrowDown.svg';
 import { useEffect, useState } from 'react';
 import { useUserStore } from '@/utils/zustand';
 import useProductByPartnerQuery from '@/hooks/reactQuery/product/useProductByPartnerQuery';
-import useModal from '@/hooks/useModal';
+// import useModal from '@/hooks/useModal';
+import useProductDeleteMutation from '@/hooks/reactQuery/product/useProductDeleteMutation';
+import { toast } from 'react-toastify';
 import SearchBar from '@/components/common/SearchBar';
 import ReservPagination from '@/components/common/reservPagination/ReservPagination';
 import PostingCard from '@/components/PostingCard';
 import PostingSwitch from '@/components/myPage/PostingSwitch';
 import ReservButtonOutlined from '@/components/myPage/ReservButtonOutlined';
-import DeletePosting from '@/components/myPage/Modal/DeletePosting';
+// import DeletePosting from '@/components/myPage/Modal/DeletePosting';
 
 const PostingManagement = () => {
   const { userInfo } = useUserStore();
@@ -19,7 +21,7 @@ const PostingManagement = () => {
   const [allData, setAllData] = useState<any[]>([]);
 
   const { postingData: allPost } = useProductByPartnerQuery(userInfo.id);
-  const { isModalOpen, openModal, closeModal } = useModal();
+  // const { isModalOpen, openModal, closeModal } = useModal();
 
   const sortData = (data: any[], postNew: boolean) => {
     if (!Array.isArray(data)) return [];
@@ -36,6 +38,13 @@ const PostingManagement = () => {
 
   const handleCategoryClick = (category: string) => {
     setSelectedCategory(category);
+  };
+
+  const { mutate } = useProductDeleteMutation();
+
+  const handleDelete = (productId: number) => {
+    mutate(productId);
+    toast.success('게시물이 삭제되었습니다.');
   };
 
   const getCategoryCount = (category: string) => {
@@ -160,16 +169,18 @@ const PostingManagement = () => {
                             />
                           }
                           lowerRight={
-                            <ReservButtonOutlined
-                              status={5}
-                              onClick={openModal}
-                            />
+                            <>
+                              <ReservButtonOutlined
+                                status={5}
+                                onClick={() => handleDelete(item.id)}
+                              />
+                              {/* <DeletePosting
+                                id={item.id}
+                                closeModal={closeModal}
+                                isOpen={isModalOpen}
+                              /> */}
+                            </>
                           }
-                        />
-                        <DeletePosting
-                          id={item.id}
-                          closeModal={closeModal}
-                          isOpen={isModalOpen}
                         />
                       </div>
                     ))}
@@ -204,17 +215,18 @@ const PostingManagement = () => {
                             />
                           }
                           lowerRight={
-                            <ReservButtonOutlined
-                              status={5}
-                              onClick={openModal}
-                            />
+                            <>
+                              <ReservButtonOutlined
+                                status={5}
+                                onClick={() => handleDelete(item.id)}
+                              />
+                              {/* <DeletePosting
+                                id={item.id}
+                                closeModal={closeModal}
+                                isOpen={isModalOpen}
+                              /> */}
+                            </>
                           }
-                        />
-
-                        <DeletePosting
-                          id={item.id}
-                          closeModal={closeModal}
-                          isOpen={isModalOpen}
                         />
                       </div>
                     ))}
@@ -249,17 +261,18 @@ const PostingManagement = () => {
                             />
                           }
                           lowerRight={
-                            <ReservButtonOutlined
-                              status={5}
-                              onClick={openModal}
-                            />
+                            <>
+                              <ReservButtonOutlined
+                                status={5}
+                                onClick={() => handleDelete(item.id)}
+                              />
+                              {/* <DeletePosting
+                                id={item.id}
+                                closeModal={closeModal}
+                                isOpen={isModalOpen}
+                              /> */}
+                            </>
                           }
-                        />
-
-                        <DeletePosting
-                          id={item.id}
-                          closeModal={closeModal}
-                          isOpen={isModalOpen}
                         />
                       </div>
                     ))}

--- a/src/pages/PostingManagement.tsx
+++ b/src/pages/PostingManagement.tsx
@@ -76,7 +76,7 @@ const PostingManagement = () => {
       setLodgeData(sortData(lodge, isNew));
       setActivityData(sortData(activity, isNew));
     }
-  }, [isNew, allData]);
+  }, [isNew, allPost]);
 
   return (
     <div className="mx-10 my-0 w-1000">
@@ -144,9 +144,52 @@ const PostingManagement = () => {
                     allCardNum={allData.length}
                   >
                     {allData.slice(start, end).map((item) => (
-                      <>
+                      <div key={item.id}>
                         <PostingCard
-                          key={item.id}
+                          id={item.id}
+                          title={item.name}
+                          salePeriod={{
+                            startDate: item.startDate,
+                            endDate: item.endDate,
+                          }}
+                          postingDate={item.createdAt}
+                          upperRight={
+                            <PostingSwitch
+                              id={item.id}
+                              state={item.isPosting}
+                            />
+                          }
+                          lowerRight={
+                            <ReservButtonOutlined
+                              status={5}
+                              onClick={openModal}
+                            />
+                          }
+                        />
+                        <DeletePosting
+                          id={item.id}
+                          closeModal={closeModal}
+                          isOpen={isModalOpen}
+                        />
+                      </div>
+                    ))}
+                  </ReservPagination>
+                ) : (
+                  <div className="flex items-center justify-center text-24 font-medium">
+                    게시한 상품이 없습니다.
+                  </div>
+                ))}
+              {selectedCategory === '숙박' &&
+                (lodgeData.length > 0 ? (
+                  <ReservPagination
+                    limit={limit}
+                    pageNum={pageNum}
+                    setPageNum={setPageNum}
+                    allCardNum={lodgeData.length}
+                  >
+                    {lodgeData.slice(start, end).map((item) => (
+                      <div key={item.id}>
+                        <PostingCard
                           id={item.id}
                           title={item.name}
                           salePeriod={{
@@ -173,52 +216,7 @@ const PostingManagement = () => {
                           closeModal={closeModal}
                           isOpen={isModalOpen}
                         />
-                      </>
-                    ))}
-                  </ReservPagination>
-                ) : (
-                  <div className="flex items-center justify-center text-24 font-medium">
-                    게시한 상품이 없습니다.
-                  </div>
-                ))}
-              {selectedCategory === '숙박' &&
-                (lodgeData.length > 0 ? (
-                  <ReservPagination
-                    limit={limit}
-                    pageNum={pageNum}
-                    setPageNum={setPageNum}
-                    allCardNum={lodgeData.length}
-                  >
-                    {lodgeData.slice(start, end).map((item) => (
-                      <>
-                        <PostingCard
-                          key={item.id}
-                          id={item.id}
-                          title={item.name}
-                          salePeriod={{
-                            startDate: item.startDate,
-                            endDate: item.endDate,
-                          }}
-                          postingDate={item.createdAt}
-                          upperRight={
-                            <PostingSwitch
-                              id={item.id}
-                              state={item.isPosting}
-                            />
-                          }
-                          lowerRight={
-                            <ReservButtonOutlined
-                              status={5}
-                              onClick={openModal}
-                            />
-                          }
-                        />
-                        <DeletePosting
-                          id={item.id}
-                          closeModal={closeModal}
-                          isOpen={isModalOpen}
-                        />
-                      </>
+                      </div>
                     ))}
                   </ReservPagination>
                 ) : (
@@ -235,9 +233,8 @@ const PostingManagement = () => {
                     allCardNum={activityData.length}
                   >
                     {activityData.slice(start, end).map((item) => (
-                      <>
+                      <div key={item.id}>
                         <PostingCard
-                          key={item.id}
                           id={item.id}
                           title={item.name}
                           salePeriod={{
@@ -258,12 +255,13 @@ const PostingManagement = () => {
                             />
                           }
                         />
+
                         <DeletePosting
                           id={item.id}
                           closeModal={closeModal}
                           isOpen={isModalOpen}
                         />
-                      </>
+                      </div>
                     ))}
                   </ReservPagination>
                 ) : (

--- a/src/pages/PostingManagement.tsx
+++ b/src/pages/PostingManagement.tsx
@@ -5,6 +5,7 @@ import useProductByPartnerQuery from '@/hooks/reactQuery/product/useProductByPar
 import SearchBar from '@/components/common/SearchBar';
 import ReservPagination from '@/components/common/reservPagination/ReservPagination';
 import PostingCard from '@/components/PostingCard';
+// import Button from '@/components/common/Button';
 
 const PostingManagement = () => {
   const { userInfo } = useUserStore();
@@ -74,7 +75,7 @@ const PostingManagement = () => {
   }, [isNew, allPost]);
 
   return (
-    <div className="mx-10 my-0 w-1000">
+    <div className="relative mx-10 my-0 w-1000">
       <div className="flex flex-col gap-60 mt-60">
         <div className="flex flex-col gap-20">
           <div className="font-bold text-24">상품 판매(게시) 관리</div>
@@ -221,6 +222,13 @@ const PostingManagement = () => {
           </div>
         </div>
       </div>
+      {/* <Button
+        variant="floating"
+        buttonStyle="fixed bottom-90 right-40 w-240 h-56 p-12
+      bg-blue-6 text-16 font-semibold cursor-pointer shadow-lg"
+      >
+        새 상품 게시하기
+      </Button> */}
     </div>
   );
 };


### PR DESCRIPTION
## 🚀 작업 내용

- 게시물 관리
    - switch on/off 및 삭제하기 동작 후 내용이 자동으로 refetch되어 렌더링이 바로 반영되도록 변경
    - 게시물 card 클릭 시 페이지 이동(현재 : /partner/product-register)
    - (현재 비활성화) 새 게시물 등록 버튼 기능 구현
- 예약 관리
    - 예약 거절 시, '취소하기' 버튼 삭제
    - 예약 관리 시, dependency array 관련 오류 일부 수정

## 📝 참고 사항

- 추후 카드 클릭 시 해당 게시물을 편집하는 페이지로 이동할 수 있도록 변경 예정입니다.

## 🖼️ 스크린샷
![게시물 관리 동작](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/305040e1-e5ff-4112-b536-90a2e6478872)
![스크린샷 2024-06-20 194718](https://github.com/sprint4-part4-team7/TravelPort-49105/assets/79882248/1fa95718-e169-4dca-b5d7-5bca7af25d0a)

## 🚨 관련 이슈

- close-#(issue_number)
